### PR TITLE
Make project documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,40 @@
+name: docs
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install docs deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install -r docs/requirements.txt
+      - name: Build site
+        run: mkdocs build --strict --site-dir site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,12 @@ redis-cli:
 
 insight:
 	@echo "Open http://localhost:5540 and add database: $(REDIS_URL)"
+
+docs-install:
+	python -m pip install -r docs/requirements.txt
+
+docs-build:
+	mkdocs build --strict
+
+docs-serve:
+	mkdocs serve -a 0.0.0.0:8000

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: swe_ai_fleet

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+# SWE AI Fleet
+
+SWE AI Fleet is an open-source, multi-agent system for software development and systems architecture.
+It orchestrates role-based LLM agents (developers, devops, data, QA, architect) with Ray/KubeRay,
+provides safe tool wrappers (kubectl, helm, psql, etc.), and maintains a long-term knowledge graph
+(Neo4j) plus a short-term memory (Redis).
+
+## Quick Start (local dev)
+
+- Requirements: Python 3.13+, Docker, kind, kubectl, helm.
+- Create a virtual env, install dev deps, and run the local stack via scripts in `scripts/`.
+- See `deploy/helm` for Redis, Neo4j, and KubeRay chart.
+
+## Repository Layout
+
+See the `swe_ai_fleet/` tree for folders and roles.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocstrings>=0.25
+mkdocstrings-python>=1.10
+pymdown-extensions>=10.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,53 @@
+site_name: SWE AI Fleet
+site_description: Multi-agent SWE at the edge. Local-first, open-source.
+repo_url: https://github.com/tgarciai/swe-ai-fleet
+repo_name: tgarciai/swe-ai-fleet
+site_dir: site
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.tracking
+    - toc.integrate
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            heading_level: 2
+            separate_signature: true
+            filters: ["!^_"]
+            warn_on_error: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Guides:
+      - Formatting: FORMATTING.md
+      - Git Workflow: GIT_WORKFLOW.md
+  - Architecture:
+      - ADR: ADR-0001-license.md
+      - RFCs:
+          - RFC-0001: RFC-0001-bootstrap.md
+          - RFC-0002: RFC-0002-persistent-scoped-memory.md
+          - RFC-0003: RFC-0003-collaboration-flow.md
+  - API Reference: api.md


### PR DESCRIPTION
## Summary

Scaffolded a comprehensive documentation site using MkDocs with the Material theme, including an API reference generated by `mkdocstrings`, and set up GitHub Actions for automatic deployment to GitHub Pages. Integrated existing documentation files and added Makefile targets for local development.

## Type

- [ ] chore(hardening)
- [ ] fix
- [ ] feat
- [x] docs

## Tests

- [ ] Unit tests added/updated
- [x] CI green

## Notes

Local development commands:
- Install dependencies: `make docs-install`
- Serve locally: `make docs-serve` (then open http://localhost:8000)
- Build site: `make docs-build`

---
<a href="https://cursor.com/background-agent?bcId=bc-9956fe69-5c99-4f7d-8753-e39aae28301d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9956fe69-5c99-4f7d-8753-e39aae28301d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

