### PR TITLE
Create github logo for swe-ai-fleet

### DIFF
--- a/BRANDING.md
+++ b/BRANDING.md
@@ -1,0 +1,101 @@
+# SWE AI Fleet - Branding Guide
+
+## Logo Files
+
+This repository contains the following logo assets:
+
+- **`logo.svg`** - Main logo (512x512px) - High resolution, scalable vector format
+- **`logo-favicon.svg`** - Favicon version (32x32px) - Simplified for small sizes
+
+## Logo Design Concept
+
+The SWE AI Fleet logo represents the core concept of the project:
+
+### Central Elements
+- **Central Hub**: A blue circular node with `{}` representing software engineering and code
+- **Agent Network**: 5 specialized AI agents positioned around the hub:
+  - **DEV** (Developer) - Green
+  - **OPS** (DevOps) - Cyan  
+  - **QA** (Quality Assurance) - Blue
+  - **DATA** (Data Engineer) - Green
+  - **ARCH** (Architect) - Cyan
+
+### Technology Stack Indicators
+- **Redis** - Memory and caching
+- **Neo4j** - Knowledge graph
+- **Ray** - Distributed computing
+- **K8s** - Kubernetes orchestration
+
+### Visual Style
+- **Color Palette**: Modern tech colors (blues, cyans, greens)
+- **Background**: Dark gradient (slate-800 to slate-900)
+- **Effects**: Subtle glow effects and gradients
+- **Typography**: Monospace for technical elements, system fonts for branding
+
+## Usage Guidelines
+
+### GitHub Repository
+- Use `logo.svg` as the main repository image
+- Use `logo-favicon.svg` for the repository favicon
+
+### Documentation
+- Use the main logo for README headers
+- Use the favicon for documentation sites
+- Maintain aspect ratio when resizing
+
+### Social Media
+- Use the main logo for profile pictures (crop to square if needed)
+- Use the main logo for post graphics
+- Ensure minimum size of 200x200px for visibility
+
+### Print Materials
+- Use the SVG version for high-quality printing
+- Minimum size: 1 inch (25.4mm) for legibility
+- Use CMYK color space for professional printing
+
+## Color Specifications
+
+### Primary Colors
+- **Primary Blue**: `#3b82f6` to `#1d4ed8` (gradient)
+- **Accent Cyan**: `#06b6d4` to `#0891b2` (gradient)
+- **Success Green**: `#10b981` to `#059669` (gradient)
+
+### Background Colors
+- **Dark Slate**: `#1e293b` to `#0f172a` (gradient)
+- **Grid Pattern**: `#334155` (subtle)
+
+### Text Colors
+- **Primary Text**: `#ffffff` (white)
+- **Secondary Text**: `#94a3b8` (slate-400)
+
+## Logo Variations
+
+### Monochrome Version
+For single-color applications, use the central hub design with the `{}` symbol.
+
+### Horizontal Layout
+For wide formats, the logo can be adapted to a horizontal layout with agents arranged in a row.
+
+## Brand Voice
+
+The logo reflects SWE AI Fleet's brand values:
+- **Innovation**: Modern, tech-forward design
+- **Collaboration**: Network of interconnected agents
+- **Professionalism**: Clean, enterprise-ready aesthetic
+- **Open Source**: Accessible, community-focused design
+
+## License
+
+The logo and branding assets are part of the SWE AI Fleet project and are licensed under the same terms as the project codebase.
+
+## Contributing
+
+When contributing to the project's visual identity:
+- Maintain consistency with the established design language
+- Ensure accessibility (adequate contrast ratios)
+- Test logos at various sizes and contexts
+- Follow the color specifications provided
+
+---
+
+*For questions about branding or logo usage, please open an issue in the repository.*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # SWE AI Fleet
 
+<div align="center">
+  <img src="logo.svg" alt="SWE AI Fleet Logo" width="200" height="200">
+  <h3>Multi-Agent Software Engineering at the Edge</h3>
+</div>
+
 [![CI](https://github.com/tgarciai/swe-ai-fleet/actions/workflows/ci.yml/badge.svg)](https://github.com/tgarciai/swe-ai-fleet/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=tgarciai_swe-ai-fleet&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=tgarciai_swe-ai-fleet)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=tgarciai_swe-ai-fleet&metric=coverage)](https://sonarcloud.io/summary/new_code?id=tgarciai_swe-ai-fleet)
+[![Coverage](https://sonarcloud.io/api/project/badges/measure?project=tgarciai_swe-ai-fleet&metric=coverage)](https://sonarcloud.io/summary/new_code?id=tgarciai_swe-ai-fleet)
 
 SWE AI Fleet is an open-source, multi-agent system for software development and systems architecture.
 It orchestrates role-based LLM agents (developers, devops, data, QA, architect) with Ray/KubeRay,

--- a/logo-favicon.svg
+++ b/logo-favicon.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0f172a;stop-opacity:1" />
+    </linearGradient>
+    
+    <linearGradient id="primaryGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1d4ed8;stop-opacity:1" />
+    </linearGradient>
+    
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0891b2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="32" height="32" rx="6" fill="url(#bgGradient)"/>
+  
+  <!-- Central hub -->
+  <circle cx="16" cy="16" r="8" fill="url(#primaryGradient)"/>
+  <circle cx="16" cy="16" r="6" fill="url(#accentGradient)"/>
+  
+  <!-- Code brackets -->
+  <text x="16" y="20" font-family="monospace" font-size="8" font-weight="bold" text-anchor="middle" fill="white">{}</text>
+  
+  <!-- Small agent nodes -->
+  <circle cx="8" cy="8" r="3" fill="url(#accentGradient)"/>
+  <circle cx="24" cy="8" r="3" fill="url(#primaryGradient)"/>
+  <circle cx="8" cy="24" r="3" fill="url(#primaryGradient)"/>
+  <circle cx="24" cy="24" r="3" fill="url(#accentGradient)"/>
+</svg>

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0f172a;stop-opacity:1" />
+    </linearGradient>
+    
+    <linearGradient id="primaryGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1d4ed8;stop-opacity:1" />
+    </linearGradient>
+    
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#0891b2;stop-opacity:1" />
+    </linearGradient>
+    
+    <linearGradient id="successGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10b981;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1" />
+    </linearGradient>
+    
+    <!-- Glow effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge> 
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="innerGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feComposite in="SourceGraphic" in2="coloredBlur" operator="over"/>
+    </filter>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="512" height="512" rx="64" fill="url(#bgGradient)"/>
+  
+  <!-- Central hub/network node -->
+  <circle cx="256" cy="256" r="80" fill="url(#primaryGradient)" filter="url(#glow)"/>
+  <circle cx="256" cy="256" r="60" fill="url(#accentGradient)" filter="url(#innerGlow)"/>
+  
+  <!-- Central icon: Code brackets representing software engineering -->
+  <text x="256" y="270" font-family="monospace" font-size="32" font-weight="bold" text-anchor="middle" fill="white">{}</text>
+  
+  <!-- AI Agent nodes around the central hub -->
+  <!-- Developer Agent (top-left) -->
+  <circle cx="140" cy="140" r="35" fill="url(#successGradient)" filter="url(#glow)"/>
+  <text x="140" y="148" font-family="monospace" font-size="16" font-weight="bold" text-anchor="middle" fill="white">DEV</text>
+  
+  <!-- DevOps Agent (top-right) -->
+  <circle cx="372" cy="140" r="35" fill="url(#accentGradient)" filter="url(#glow)"/>
+  <text x="372" y="148" font-family="monospace" font-size="16" font-weight="bold" text-anchor="middle" fill="white">OPS</text>
+  
+  <!-- QA Agent (bottom-left) -->
+  <circle cx="140" cy="372" r="35" fill="url(#primaryGradient)" filter="url(#glow)"/>
+  <text x="140" y="380" font-family="monospace" font-size="16" font-weight="bold" text-anchor="middle" fill="white">QA</text>
+  
+  <!-- Data Engineer Agent (bottom-right) -->
+  <circle cx="372" cy="372" r="35" fill="url(#successGradient)" filter="url(#glow)"/>
+  <text x="372" y="380" font-family="monospace" font-size="16" font-weight="bold" text-anchor="middle" fill="white">DATA</text>
+  
+  <!-- Architect Agent (top center) -->
+  <circle cx="256" cy="80" r="35" fill="url(#accentGradient)" filter="url(#glow)"/>
+  <text x="256" y="88" font-family="monospace" font-size="16" font-weight="bold" text-anchor="middle" fill="white">ARCH</text>
+  
+  <!-- Connection lines between agents and central hub -->
+  <line x1="175" y1="175" x2="196" y2="196" stroke="url(#primaryGradient)" stroke-width="3" opacity="0.7"/>
+  <line x1="337" y1="175" x2="316" y2="196" stroke="url(#primaryGradient)" stroke-width="3" opacity="0.7"/>
+  <line x1="175" y1="337" x2="196" y2="316" stroke="url(#primaryGradient)" stroke-width="3" opacity="0.7"/>
+  <line x1="337" y1="337" x2="316" y2="316" stroke="url(#primaryGradient)" stroke-width="3" opacity="0.7"/>
+  <line x1="256" y1="115" x2="256" y2="196" stroke="url(#primaryGradient)" stroke-width="3" opacity="0.7"/>
+  
+  <!-- Data flow indicators (small arrows) -->
+  <g fill="url(#accentGradient)" opacity="0.8">
+    <!-- Clockwise flow -->
+    <path d="M 200 120 L 195 125 L 200 130 L 205 125 Z"/>
+    <path d="M 320 200 L 325 195 L 330 200 L 325 205 Z"/>
+    <path d="M 312 320 L 307 325 L 312 330 L 317 325 Z"/>
+    <path d="M 192 312 L 187 307 L 192 302 L 197 307 Z"/>
+  </g>
+  
+  <!-- Technology stack indicators -->
+  <!-- Redis indicator -->
+  <rect x="40" y="40" width="60" height="30" rx="15" fill="url(#successGradient)" opacity="0.9"/>
+  <text x="70" y="60" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="white">Redis</text>
+  
+  <!-- Neo4j indicator -->
+  <rect x="412" y="40" width="60" height="30" rx="15" fill="url(#accentGradient)" opacity="0.9"/>
+  <text x="442" y="60" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="white">Neo4j</text>
+  
+  <!-- Ray indicator -->
+  <rect x="40" y="442" width="60" height="30" rx="15" fill="url(#primaryGradient)" opacity="0.9"/>
+  <text x="70" y="462" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="white">Ray</text>
+  
+  <!-- Kubernetes indicator -->
+  <rect x="412" y="442" width="60" height="30" rx="15" fill="url(#successGradient)" opacity="0.9"/>
+  <text x="442" y="462" font-family="monospace" font-size="12" font-weight="bold" text-anchor="middle" fill="white">K8s</text>
+  
+  <!-- Subtle grid pattern in background -->
+  <defs>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#334155" stroke-width="0.5" opacity="0.3"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" fill="url(#grid)"/>
+  
+  <!-- Project name at the bottom -->
+  <text x="256" y="480" font-family="system-ui, -apple-system, sans-serif" font-size="24" font-weight="600" text-anchor="middle" fill="white">SWE AI Fleet</text>
+  
+  <!-- Tagline -->
+  <text x="256" y="500" font-family="system-ui, -apple-system, sans-serif" font-size="12" text-anchor="middle" fill="#94a3b8">Multi-Agent Software Engineering</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds a new project logo (`logo.svg`), a favicon (`logo-favicon.svg`), and a `BRANDING.md` guide to establish the visual identity for the `swe-ai-fleet` project. The `README.md` has been updated to include the new logo.

## Type

- [x] chore(hardening)
- [ ] fix
- [ ] feat
- [ ] docs

## Tests

- [ ] Unit tests added/updated
- [x] CI green

## Notes

The logo visually represents the project's core concept: a fleet of specialized AI agents for software engineering, emphasizing collaboration, technology, and the integrated tech stack (Redis, Neo4j, Ray, K8s). The branding guide provides specifications and usage guidelines for various contexts (GitHub, documentation, social media).

---
<a href="https://cursor.com/background-agent?bcId=bc-e37f7bcc-975e-48b1-886f-a678a5fee6ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e37f7bcc-975e-48b1-886f-a678a5fee6ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

