### PR TITLE
Implement graph analytics integration in report generation

### DIFF
--- a/src/swe_ai_fleet/reports/adapters/neo4j_graph_analytics_read_adapter.py
+++ b/src/swe_ai_fleet/reports/adapters/neo4j_graph_analytics_read_adapter.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from swe_ai_fleet.memory.neo4j_store import Neo4jStore
+from swe_ai_fleet.reports.domain.graph_analytics_types import (
+    AgentMetrics,
+    CriticalNode,
+    LayeredTopology,
+    PathCycle,
+)
+from swe_ai_fleet.reports.ports.graph_analytics_read_port import GraphAnalyticsReadPort
+
+
+class Neo4jGraphAnalyticsReadAdapter(GraphAnalyticsReadPort):
+    """Analytics adapter using a thin `Neo4jStore` wrapper.
+
+    It assumes the decision graph is projected as in the decision read adapter:
+    (:Case {id})-[:HAS_PLAN]->(:PlanVersion)
+    (:PlanVersion)-[:CONTAINS_DECISION]->(:Decision)
+    (Decision)-[REL]->(Decision) with domain relations (e.g. DEPENDS_ON, GOVERNS, BLOCKS, ...)
+
+    Notes:
+    * All queries are **scoped to the latest PlanVersion** of the case.
+    * We avoid relying on GDS; we provide indegree-based fallback and in-Python layering.
+    """
+
+    def __init__(self, store: Neo4jStore) -> None:
+        self._store = store
+
+    # ---------- Critical decisions (indegree fallback) ----------
+    def get_critical_decisions(self, case_id: str, limit: int = 10) -> list[CriticalNode]:
+        # Use a subgraph of Decision nodes under the latest PlanVersion for this case.
+        q = (
+            "MATCH (c:Case {id:$cid})-[:HAS_PLAN]->(p:PlanVersion)\n"
+            "WITH p ORDER BY coalesce(p.version,0) DESC LIMIT 1\n"
+            "MATCH (p)-[:CONTAINS_DECISION]->(d:Decision)\n"
+            "WITH collect(d) AS D\n"
+            "UNWIND D AS m\n"
+            "OPTIONAL MATCH (m)<-[r]-(:Decision)\n"
+            "WHERE ALL(x IN [startNode(r), endNode(r)] WHERE x:Decision) "
+            "AND endNode(r) IN D AND startNode(r) IN D\n"
+            "WITH m, count(r) AS indeg\n"
+            "RETURN m.id AS id, 'Decision' AS label, toFloat(indeg) AS score\n"
+            "ORDER BY score DESC LIMIT $limit"
+        )
+        recs = self._store.query(q, {"cid": case_id, "limit": limit})
+        out: list[CriticalNode] = []
+        for r in recs:
+            out.append(
+                CriticalNode(
+                    id=str(r.get("id") or ""),
+                    label=str(r.get("label") or "Decision"),
+                    score=float(r.get("score") or 0.0),
+                )
+            )
+        return out
+
+    def find_cycles(self, case_id: str, max_depth: int = 6) -> list[PathCycle]:
+        q = (
+            "MATCH (c:Case {id:$cid})-[:HAS_PLAN]->(p:PlanVersion)\n"
+            "WITH p ORDER BY coalesce(p.version,0) DESC LIMIT 1\n"
+            "MATCH (p)-[:CONTAINS_DECISION]->(d:Decision)\n"
+            "WITH collect(d) AS D\n"
+            "UNWIND D AS start\n"
+            "MATCH p=(start)-[r*1..$maxDepth]->(start)\n"
+            "WHERE ALL(rel IN r WHERE startNode(rel):Decision AND endNode(rel):Decision "
+            "AND startNode(rel) IN D AND endNode(rel) IN D)\n"
+            "RETURN [x IN nodes(p) | x.id] AS nodes, [rel IN relationships(p) | type(rel)] AS rels\n"
+            "LIMIT 20"
+        )
+        rows = self._store.query(q, {"cid": case_id, "maxDepth": max_depth})
+        out: list[PathCycle] = []
+        for r in rows:
+            nodes = [str(x) for x in (r.get("nodes") or [])]
+            rels = [str(x) for x in (r.get("rels") or [])]
+            out.append(PathCycle(nodes=nodes, rels=rels))
+        return out
+
+    # ---------- Topological layers (Kahn in Python) ----------
+    def topo_layers(self, case_id: str) -> LayeredTopology:
+        # Pull the node set and edges within the latest plan, then layer them.
+        q = (
+            "MATCH (c:Case {id:$cid})-[:HAS_PLAN]->(p:PlanVersion)\n"
+            "WITH p ORDER BY coalesce(p.version,0) DESC LIMIT 1\n"
+            "MATCH (p)-[:CONTAINS_DECISION]->(d:Decision)\n"
+            "WITH collect(d) AS D\n"
+            "UNWIND D AS d1\n"
+            "OPTIONAL MATCH (d1)-[r]->(d2:Decision)\n"
+            "WHERE d2 IN D\n"
+            "WITH collect(DISTINCT d1.id) AS nodes, collect({src:d1.id, dst:d2.id}) AS edges\n"
+            "RETURN nodes, edges"
+        )
+        rows = self._store.query(q, {"cid": case_id})
+        if not rows:
+            return LayeredTopology(layers=[])
+
+        nodes: list[str] = [str(x) for x in (rows[0].get("nodes") or [])]
+        pairs: list[dict[str, Any]] = [e for e in (rows[0].get("edges") or []) if e.get("dst")]
+
+        # Build indegree and adjacency only within the given node set
+        node_set = set(nodes)
+        indeg: dict[str, int] = {n: 0 for n in node_set}
+        adj: dict[str, list[str]] = defaultdict(list)
+        for e in pairs:
+            src, dst = str(e.get("src")), str(e.get("dst"))
+            if src in node_set and dst in node_set:
+                adj[src].append(dst)
+                indeg[dst] = indeg.get(dst, 0) + 1
+                indeg.setdefault(src, 0)
+
+        # Kahn's algorithm
+        layers: list[list[str]] = []
+        remaining = set(node_set)
+        while remaining:
+            layer = [n for n in remaining if indeg.get(n, 0) == 0]
+            if not layer:
+                # Cycle remainder: output them as the final layer deterministically
+                layers.append(sorted(list(remaining)))
+                break
+            layers.append(sorted(layer))
+            for n in layer:
+                remaining.remove(n)
+                for m in adj.get(n, []):
+                    indeg[m] -= 1
+        return LayeredTopology(layers=layers)
+
+    # ---------- Placeholder for future metrics ----------
+    def agent_metrics(self, agent_id: str, since_iso: str) -> AgentMetrics:  # pragma: no cover (not used yet)
+        return AgentMetrics(
+            agent_id=agent_id,
+            total_runs=0,
+            success_rate=0.0,
+            p50_duration_ms=0.0,
+            p95_duration_ms=0.0,
+        )

--- a/src/swe_ai_fleet/reports/domain/graph_analytics_types.py
+++ b/src/swe_ai_fleet/reports/domain/graph_analytics_types.py
@@ -1,0 +1,48 @@
+
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CriticalNode:
+    id: str
+    label: str  # e.g. "Decision"
+    score: float  # centrality/indegree fallback
+
+
+
+
+@dataclass(frozen=True)
+class PathCycle:
+    nodes: list[str]
+    rels: list[str]
+
+
+
+
+@dataclass(frozen=True)
+class LayeredTopology:
+    layers: list[list[str]]  # layer 0 -> ... -> N
+
+
+
+
+@dataclass(frozen=True)
+class AgentMetrics:
+    agent_id: str
+    total_runs: int
+    success_rate: float
+    p50_duration_ms: float
+    p95_duration_ms: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "total_runs": self.total_runs,
+            "success_rate": self.success_rate,
+            "p50_duration_ms": self.p50_duration_ms,
+            "p95_duration_ms": self.p95_duration_ms,
+        }

--- a/src/swe_ai_fleet/reports/ports/graph_analytics_read_port.py
+++ b/src/swe_ai_fleet/reports/ports/graph_analytics_read_port.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from swe_ai_fleet.reports.domain.graph_analytics_types import (
+    AgentMetrics,
+    CriticalNode,
+    LayeredTopology,
+    PathCycle,
+)
+
+
+class GraphAnalyticsReadPort(Protocol):
+    """Read-only analytics queries over the decision graph.
+
+    All methods are **scoped to the latest PlanVersion** of the provided case.
+    Implementations should prefer parameterized Cypher and avoid dynamic string concatenation.
+    """
+
+    def get_critical_decisions(self, case_id: str, limit: int = 10) -> list[CriticalNode]: ...
+
+    def find_cycles(self, case_id: str, max_depth: int = 6) -> list[PathCycle]: ...
+
+    def topo_layers(self, case_id: str) -> LayeredTopology: ...
+
+    # Optional: not implemented in the adapter yet (kept for future Mx)
+    def agent_metrics(self, agent_id: str, since_iso: str) -> AgentMetrics: ...

--- a/tests/e2e/test_report_usecase_e2e.py
+++ b/tests/e2e/test_report_usecase_e2e.py
@@ -1,6 +1,7 @@
 import json
 import time
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import redis
@@ -10,6 +11,32 @@ from swe_ai_fleet.reports.adapters.redis_planning_read_adapter import (
 )
 from swe_ai_fleet.reports.domain.report_request import ReportRequest
 from swe_ai_fleet.reports.report_usecase import ImplementationReportUseCase
+
+# Mock analytics types for testing
+try:
+    from swe_ai_fleet.reports.domain.graph_analytics_types import (
+        CriticalNode,
+        LayeredTopology,
+        PathCycle,
+    )
+except ImportError:
+    # Fallback for environments without analytics types
+    from dataclasses import dataclass
+
+    @dataclass(frozen=True)
+    class CriticalNode:
+        id: str
+        label: str
+        score: float
+
+    @dataclass(frozen=True)
+    class PathCycle:
+        nodes: list[str]
+        rels: list[str]
+
+    @dataclass(frozen=True)
+    class LayeredTopology:
+        layers: list[list[str]]
 
 pytestmark = pytest.mark.e2e
 
@@ -48,6 +75,22 @@ def _cleanup_case(r: redis.Redis, case_id: str) -> None:
         _k_report_last(case_id),
     ]
     r.delete(*keys)
+
+
+def _make_analytics_port() -> MagicMock:
+    """Create a mock analytics port for testing."""
+    analytics_port = MagicMock()
+    analytics_port.get_critical_decisions.return_value = [
+        CriticalNode(id="D1", label="Decision", score=5.0),
+        CriticalNode(id="D2", label="Decision", score=3.0),
+    ]
+    analytics_port.find_cycles.return_value = [
+        PathCycle(nodes=["D1", "D2", "D1"], rels=["DEPENDS_ON", "BLOCKS"]),
+    ]
+    analytics_port.topo_layers.return_value = LayeredTopology(
+        layers=[["D1"], ["D2", "D3"], ["D4"]]
+    )
+    return analytics_port
 
 
 def test_report_usecase_e2e_end_to_end():
@@ -135,3 +178,179 @@ def test_report_usecase_e2e_end_to_end():
     assert "Implementation Report" in report.markdown
     assert f"`{case_id}`" in report.markdown
     assert "Planning Timeline" in report.markdown
+
+    # Validate no analytics section when analytics port is not provided
+    assert "Graph Analytics (Decisions)" not in report.markdown
+    assert "Critical Decisions (by indegree)" not in report.markdown
+    assert "Cycles" not in report.markdown
+    assert "Topological Layers" not in report.markdown
+
+
+def test_report_usecase_e2e_with_analytics():
+    url = "redis://:swefleet-dev@localhost:6379/0"
+    r: redis.Redis = redis.Redis.from_url(url, decode_responses=True)
+
+    case_id = f"e2e-analytics-{int(time.time())}"
+    _cleanup_case(r, case_id)
+
+    # Seed case spec
+    spec_doc: dict[str, Any] = {
+        "case_id": case_id,
+        "title": "E2E Analytics Case",
+        "description": "End-to-end report generation with analytics",
+        "acceptance_criteria": ["works with analytics"],
+        "constraints": {"env": "prod"},
+        "requester_id": "user-1",
+        "tags": ["e2e", "analytics"],
+        "created_at_ms": int(time.time() * 1000),
+    }
+    r.set(_k_spec(case_id), json.dumps(spec_doc))
+
+    # Seed plan draft with one subtask
+    draft_doc: dict[str, Any] = {
+        "plan_id": "P1",
+        "case_id": case_id,
+        "version": 1,
+        "status": "draft",
+        "author_id": "bot",
+        "rationale": "because analytics",
+        "created_at_ms": int(time.time() * 1000),
+        "subtasks": [
+            {
+                "subtask_id": "S1",
+                "title": "Implement Analytics",
+                "description": "Do analytics",
+                "role": "dev",
+                "suggested_tech": ["python", "neo4j"],
+                "depends_on": [],
+                "estimate_points": 3.0,
+                "priority": 1,
+                "risk_score": 0.2,
+                "notes": "analytics integration",
+            }
+        ],
+    }
+    r.set(_k_draft(case_id), json.dumps(draft_doc))
+
+    # Seed planning events
+    r.xadd(
+        _k_stream(case_id),
+        {"event": "created", "actor": "user", "payload": json.dumps({"analytics": True}), "ts": "1"},
+    )
+
+    # Build use case with Redis-backed adapter and analytics port
+    adapter = RedisPlanningReadAdapter(r)
+    analytics_port = _make_analytics_port()
+    usecase = ImplementationReportUseCase(adapter, analytics_port=analytics_port)
+
+    req = ReportRequest(
+        case_id=case_id,
+        include_constraints=True,
+        include_acceptance=True,
+        include_timeline=True,
+        include_dependencies=True,
+        persist_to_redis=True,
+        ttl_seconds=120,
+    )
+
+    report = usecase.generate(req)
+
+    # Validate persistence
+    last_id = r.get(_k_report_last(case_id))
+    assert last_id is not None
+    doc_raw = r.get(_k_report_doc(case_id, last_id))
+    assert doc_raw is not None
+    doc = json.loads(doc_raw)
+    assert doc["case_id"] == case_id
+
+    # Validate content looks correct
+    assert report.plan_id == "P1"
+    assert "Implementation Report" in report.markdown
+    assert f"`{case_id}`" in report.markdown
+    assert "Planning Timeline" in report.markdown
+
+    # Validate analytics section is included
+    assert "Graph Analytics (Decisions)" in report.markdown
+    assert "Critical Decisions (by indegree)" in report.markdown
+    assert "`D1` — score 5.00" in report.markdown
+    assert "`D2` — score 3.00" in report.markdown
+    assert "Cycles" in report.markdown
+    assert "Cycle 1: D1 -> D2 -> D1" in report.markdown
+    assert "Topological Layers" in report.markdown
+    assert "Layer 0: D1" in report.markdown
+    assert "Layer 1: D2, D3" in report.markdown
+    assert "Layer 2: D4" in report.markdown
+
+    # Validate analytics port was called correctly
+    analytics_port.get_critical_decisions.assert_called_once_with(case_id, limit=10)
+    analytics_port.find_cycles.assert_called_once_with(case_id, max_depth=6)
+    analytics_port.topo_layers.assert_called_once_with(case_id)
+
+
+def test_report_usecase_e2e_analytics_empty_results():
+    url = "redis://:swefleet-dev@localhost:6379/0"
+    r: redis.Redis = redis.Redis.from_url(url, decode_responses=True)
+
+    case_id = f"e2e-analytics-empty-{int(time.time())}"
+    _cleanup_case(r, case_id)
+
+    # Seed case spec
+    spec_doc: dict[str, Any] = {
+        "case_id": case_id,
+        "title": "E2E Analytics Empty Case",
+        "description": "End-to-end report generation with empty analytics",
+        "acceptance_criteria": ["works with empty analytics"],
+        "constraints": {"env": "prod"},
+        "requester_id": "user-1",
+        "tags": ["e2e", "analytics"],
+        "created_at_ms": int(time.time() * 1000),
+    }
+    r.set(_k_spec(case_id), json.dumps(spec_doc))
+
+    # Seed plan draft
+    draft_doc: dict[str, Any] = {
+        "plan_id": "P1",
+        "case_id": case_id,
+        "version": 1,
+        "status": "draft",
+        "author_id": "bot",
+        "rationale": "because empty analytics",
+        "created_at_ms": int(time.time() * 1000),
+        "subtasks": [],
+    }
+    r.set(_k_draft(case_id), json.dumps(draft_doc))
+
+    # Build use case with Redis-backed adapter and empty analytics port
+    adapter = RedisPlanningReadAdapter(r)
+    analytics_port = MagicMock()
+    analytics_port.get_critical_decisions.return_value = []
+    analytics_port.find_cycles.return_value = []
+    analytics_port.topo_layers.return_value = LayeredTopology(layers=[])
+    
+    usecase = ImplementationReportUseCase(adapter, analytics_port=analytics_port)
+
+    req = ReportRequest(
+        case_id=case_id,
+        include_constraints=True,
+        include_acceptance=True,
+        include_timeline=True,
+        include_dependencies=True,
+        persist_to_redis=True,
+        ttl_seconds=120,
+    )
+
+    report = usecase.generate(req)
+
+    # Validate analytics section shows empty states
+    assert "Graph Analytics (Decisions)" in report.markdown
+    assert "Critical Decisions (by indegree)" in report.markdown
+    assert "- (none)" in report.markdown
+    assert "Cycles" in report.markdown
+    assert "- (none)" in report.markdown
+    assert "Topological Layers" in report.markdown
+    assert "- (none)" in report.markdown
+
+    # Validate analytics port was called correctly
+    analytics_port.get_critical_decisions.assert_called_once_with(case_id, limit=10)
+    analytics_port.find_cycles.assert_called_once_with(case_id, max_depth=6)
+    analytics_port.topo_layers.assert_called_once_with(case_id)

--- a/tests/unit/test_neo4j_graph_analytics_read_adapter_unit.py
+++ b/tests/unit/test_neo4j_graph_analytics_read_adapter_unit.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+# Ensure adapter import works without the real 'neo4j' package (mirrors existing test style)
+if "neo4j" not in sys.modules:
+    fake_neo4j = types.ModuleType("neo4j")
+
+    class _FakeGraphDatabase:
+        @staticmethod
+        def driver(*_args, **_kwargs):
+            return None
+
+    fake_neo4j.GraphDatabase = _FakeGraphDatabase
+    sys.modules["neo4j"] = fake_neo4j
+
+from swe_ai_fleet.reports.adapters.neo4j_graph_analytics_read_adapter import (
+    Neo4jGraphAnalyticsReadAdapter,
+)
+from swe_ai_fleet.reports.domain.graph_analytics_types import (
+    CriticalNode,
+    LayeredTopology,
+    PathCycle,
+)
+
+
+class _FakeStore:
+    def __init__(self, results: dict[str, list[dict[str, Any]]]):
+        self._results = results
+
+    def query(self, cypher: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        # route by unique RETURN signatures we used in the adapter
+        if "RETURN m.id AS id, 'Decision' AS label, toFloat(indeg) AS score" in cypher:
+            return self._results.get("critical", [])
+        if "RETURN [x IN nodes(p) | x.id] AS nodes, [rel IN relationships(p) | type(rel)] AS rels" in cypher:
+            return self._results.get("cycles", [])
+        if "RETURN nodes, edges" in cypher:
+            return self._results.get("layers", [])
+        return []
+
+
+def _make(results: dict[str, list[dict[str, Any]]]) -> Neo4jGraphAnalyticsReadAdapter:
+    return Neo4jGraphAnalyticsReadAdapter(_FakeStore(results))
+
+
+def test_critical_nodes_mapping():
+    adapter = _make({
+        "critical": [
+            {"id": "D2", "label": "Decision", "score": 3.0},
+            {"id": "D1", "label": "Decision", "score": 1.0},
+        ]
+    })
+    lst = adapter.get_critical_decisions("C1", limit=10)
+    assert [c.id for c in lst] == ["D2", "D1"]
+    assert all(isinstance(x, CriticalNode) for x in lst)
+
+
+def test_cycles_mapping():
+    adapter = _make({
+        "cycles": [
+            {"nodes": ["D1", "D2", "D1"], "rels": ["DEPENDS_ON", "BLOCKS"]}
+        ]
+    })
+    cycles = adapter.find_cycles("C1", max_depth=6)
+    assert len(cycles) == 1
+    assert isinstance(cycles[0], PathCycle)
+    assert cycles[0].nodes[0] == "D1"
+
+
+def test_layers_kahn():
+    # Graph: D1 -> D2, D1 -> D3, D2 -> D4, D3 -> D4
+    adapter = _make({
+        "layers": [
+            {
+                "nodes": ["D1", "D2", "D3", "D4"],
+                "edges": [
+                    {"src": "D1", "dst": "D2"},
+                    {"src": "D1", "dst": "D3"},
+                    {"src": "D2", "dst": "D4"},
+                    {"src": "D3", "dst": "D4"},
+                ],
+            }
+        ]
+    })
+    topo = adapter.topo_layers("C1")
+    assert isinstance(topo, LayeredTopology)
+    # Valid layering: D1 | D2,D3 | D4 (order inside layer not guaranteed, we sort in adapter)
+    assert set(topo.layers[2]) == {"D4"}
+
+
+def test_critical_nodes_empty():
+    adapter = _make({"critical": []})
+    lst = adapter.get_critical_decisions("C1", limit=10)
+    assert lst == []
+
+
+def test_cycles_empty():
+    adapter = _make({"cycles": []})
+    cycles = adapter.find_cycles("C1", max_depth=6)
+    assert cycles == []
+
+
+def test_layers_empty():
+    adapter = _make({"layers": []})
+    topo = adapter.topo_layers("C1")
+    assert isinstance(topo, LayeredTopology)
+    assert topo.layers == []
+
+
+def test_critical_nodes_with_limit():
+    adapter = _make({
+        "critical": [
+            {"id": "D1", "label": "Decision", "score": 5.0},
+            {"id": "D2", "label": "Decision", "score": 3.0},
+            {"id": "D3", "label": "Decision", "score": 1.0},
+        ]
+    })
+    lst = adapter.get_critical_decisions("C1", limit=2)
+    # The adapter uses LIMIT in the Cypher query, so we expect the mock to return limited results
+    # Since our mock doesn't actually implement LIMIT, we'll test that it returns all results
+    # and verify the ordering is correct
+    assert len(lst) == 3  # All results returned by mock
+    assert lst[0].id == "D1"  # Highest score first
+    assert lst[0].score == 5.0
+    assert lst[1].id == "D2"
+    assert lst[1].score == 3.0
+    assert lst[2].id == "D3"
+    assert lst[2].score == 1.0
+
+
+def test_cycles_with_different_max_depth():
+    adapter = _make({
+        "cycles": [
+            {"nodes": ["D1", "D2", "D1"], "rels": ["DEPENDS_ON"]}
+        ]
+    })
+    cycles = adapter.find_cycles("C1", max_depth=3)
+    assert len(cycles) == 1
+    assert cycles[0].nodes == ["D1", "D2", "D1"]
+    assert cycles[0].rels == ["DEPENDS_ON"]
+
+
+def test_layers_complex_graph():
+    # Complex graph with multiple paths
+    adapter = _make({
+        "layers": [
+            {
+                "nodes": ["A", "B", "C", "D", "E", "F"],
+                "edges": [
+                    {"src": "A", "dst": "B"},
+                    {"src": "A", "dst": "C"},
+                    {"src": "B", "dst": "D"},
+                    {"src": "C", "dst": "E"},
+                    {"src": "D", "dst": "F"},
+                    {"src": "E", "dst": "F"},
+                ],
+            }
+        ]
+    })
+    topo = adapter.topo_layers("C1")
+    assert isinstance(topo, LayeredTopology)
+    assert len(topo.layers) >= 3  # Should have multiple layers
+    assert "A" in topo.layers[0]  # Root node in first layer
+    assert "F" in topo.layers[-1]  # Leaf node in last layer
+
+
+def test_layers_cycle_handling():
+    # Graph with cycle: A -> B -> C -> A
+    adapter = _make({
+        "layers": [
+            {
+                "nodes": ["A", "B", "C"],
+                "edges": [
+                    {"src": "A", "dst": "B"},
+                    {"src": "B", "dst": "C"},
+                    {"src": "C", "dst": "A"},  # Creates cycle
+                ],
+            }
+        ]
+    })
+    topo = adapter.topo_layers("C1")
+    assert isinstance(topo, LayeredTopology)
+    # Should handle cycle gracefully by putting remaining nodes in final layer
+    assert len(topo.layers) > 0
+
+
+def test_critical_nodes_data_types():
+    adapter = _make({
+        "critical": [
+            {"id": "D1", "label": "Decision", "score": 2.5},
+            {"id": "D2", "label": "Decision", "score": 0.0},
+        ]
+    })
+    lst = adapter.get_critical_decisions("C1", limit=10)
+    assert len(lst) == 2
+    assert lst[0].id == "D1"
+    assert lst[0].label == "Decision"
+    assert lst[0].score == 2.5
+    assert lst[1].score == 0.0
+
+
+def test_cycles_multiple_cycles():
+    adapter = _make({
+        "cycles": [
+            {"nodes": ["A", "B", "A"], "rels": ["DEPENDS_ON"]},
+            {"nodes": ["C", "D", "E", "C"], "rels": ["BLOCKS", "GOVERNS", "DEPENDS_ON"]},
+        ]
+    })
+    cycles = adapter.find_cycles("C1", max_depth=6)
+    assert len(cycles) == 2
+    assert cycles[0].nodes == ["A", "B", "A"]
+    assert cycles[0].rels == ["DEPENDS_ON"]
+    assert cycles[1].nodes == ["C", "D", "E", "C"]
+    assert cycles[1].rels == ["BLOCKS", "GOVERNS", "DEPENDS_ON"]
+
+
+def test_layers_single_node():
+    adapter = _make({
+        "layers": [
+            {
+                "nodes": ["A"],
+                "edges": [],
+            }
+        ]
+    })
+    topo = adapter.topo_layers("C1")
+    assert isinstance(topo, LayeredTopology)
+    assert len(topo.layers) == 1
+    assert topo.layers[0] == ["A"]
+
+
+def test_layers_disconnected_nodes():
+    adapter = _make({
+        "layers": [
+            {
+                "nodes": ["A", "B", "C"],
+                "edges": [],  # No edges - all nodes disconnected
+            }
+        ]
+    })
+    topo = adapter.topo_layers("C1")
+    assert isinstance(topo, LayeredTopology)
+    # All nodes should be in the same layer since they have no dependencies
+    assert len(topo.layers) == 1
+    assert set(topo.layers[0]) == {"A", "B", "C"}


### PR DESCRIPTION

## Summary
- Added GraphAnalyticsReadPort interface for analytics queries over decision graphs.
- Introduced Neo4jGraphAnalyticsReadAdapter to implement the analytics port using Neo4j.
- Enhanced ImplementationReportUseCase to optionally include analytics data in reports.
- Implemented new methods for rendering analytics sections in reports, including critical decisions, cycles, and topological layers.
- Updated unit and end-to-end tests to validate the integration of analytics features and ensure correct report generation with and without analytics data.


## Type

- [x] chore(hardening)
- [ ] fix
- [ ] feat
- [ ] docs

## Tests

- [x] Unit tests added/updated
- [x] CI green

## Notes
