### PR TITLE
Ingress local access docs + qualify demo image

### DIFF
--- a/deploy/k8s/deployment-demo-frontend.yaml
+++ b/deploy/k8s/deployment-demo-frontend.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-frontend
+  namespace: swe
+  labels:
+    app: demo-frontend
+    app.kubernetes.io/name: demo-frontend
+    app.kubernetes.io/part-of: swe-ai-fleet
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-frontend
+  template:
+    metadata:
+      labels:
+        app: demo-frontend
+    spec:
+      containers:
+        - name: http-echo
+          image: docker.io/hashicorp/http-echo:0.2.3
+          args:
+            - "-text=hello swe-ai-fleet from kubernetes!!"
+            - "-listen=:8080"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+
+

--- a/deploy/k8s/ingress-swe-fleet.yaml
+++ b/deploy/k8s/ingress-swe-fleet.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: swe-fleet
+  namespace: swe
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: swe-ai-fleet.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: demo-frontend
+                port:
+                  number: 8080
+    - host: demo.swe-ia-fleet.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: demo-frontend
+                port:
+                  number: 8080
+
+

--- a/deploy/k8s/namespace-swe.yaml
+++ b/deploy/k8s/namespace-swe.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: swe
+  labels:
+    app.kubernetes.io/name: swe-ai-fleet
+    app.kubernetes.io/part-of: swe-ai-fleet
+
+

--- a/deploy/k8s/service-demo-frontend.yaml
+++ b/deploy/k8s/service-demo-frontend.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-frontend
+  namespace: swe
+  labels:
+    app: demo-frontend
+    app.kubernetes.io/name: demo-frontend
+    app.kubernetes.io/part-of: swe-ai-fleet
+spec:
+  type: ClusterIP
+  selector:
+    app: demo-frontend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+
+

--- a/deploy/kustomize/calico/calico-node-cni-patch.yaml
+++ b/deploy/kustomize/calico/calico-node-cni-patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: calico-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: install-cni
+          env:
+            - name: CNI_BIN_DIR
+              value: /usr/lib/cni
+            - name: CNI_CONF_DIR
+              value: /etc/cni/net.d
+          volumeMounts:
+            - name: host-cni-lib
+              mountPath: /host/usr/lib/cni
+            - name: host-cni-lib
+              mountPath: /host/secondary-bin-dir
+      volumes:
+        - name: host-cni-lib
+          hostPath:
+            path: /usr/lib/cni
+            type: DirectoryOrCreate
+
+

--- a/deploy/kustomize/calico/kustomization.yaml
+++ b/deploy/kustomize/calico/kustomization.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://raw.githubusercontent.com/projectcalico/calico/v3.27.3/manifests/calico.yaml
+
+patches:
+  - target:
+      kind: DaemonSet
+      name: calico-node
+      namespace: kube-system
+    patch: |-
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: calico-node
+        namespace: kube-system
+      spec:
+        template:
+          spec:
+            initContainers:
+            - name: install-cni
+              env:
+              - name: CNI_BIN_DIR
+                value: /usr/lib/cni
+              - name: CNI_CONF_DIR
+                value: /etc/cni/net.d
+              volumeMounts:
+              - name: host-cni-lib
+                mountPath: /host/usr/lib/cni
+              - name: host-cni-lib
+                mountPath: /host/secondary-bin-dir
+            volumes:
+            - name: host-cni-lib
+              hostPath:
+                path: /usr/lib/cni
+                type: DirectoryOrCreate
+
+

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -10,6 +10,8 @@
 - [docs/DEPLOYMENT.md](DEPLOYMENT.md)
 - [docs/INSTALL_CRIO.md](INSTALL_CRIO.md)
 - [docs/INSTALL_K8S_CRIO_GPU.md](INSTALL_K8S_CRIO_GPU.md)
+- [docs/K8S_DEMO_RUNBOOK.md](K8S_DEMO_RUNBOOK.md)
+- [docs/INGRESS_INSTALL.md](INGRESS_INSTALL.md)
 - [deploy/crio/README.md](../deploy/crio/README.md)
 - [docs/GOLDEN_PATH.md](GOLDEN_PATH.md)
 - [docs/USE_CASES.md](USE_CASES.md)

--- a/docs/INGRESS_INSTALL.md
+++ b/docs/INGRESS_INSTALL.md
@@ -19,6 +19,21 @@ kubectl get pods -n ingress-nginx -o wide
 kubectl get svc -n ingress-nginx
 ```
 
+Verification (bare‑metal without LoadBalancer):
+
+```bash
+# Wait for controller rollout
+kubectl -n ingress-nginx rollout status deploy/ingress-nginx-controller --timeout=300s
+
+# Inspect Service (NodePort/LoadBalancer)
+kubectl -n ingress-nginx get svc ingress-nginx-controller -o wide
+```
+
+- If `EXTERNAL-IP` is `<pending>`, access via NodePort on the node IP:
+  - HTTP: NodePort (e.g., 31847)
+  - HTTPS: NodePort (e.g., 31464)
+  - Example: `http://<NODE_IP>:<NODEPORT>`
+
 Note:
 - On bare‑metal, the default Service is a `NodePort`. For a single‑node lab, access via `http://<nodeIP>:<nodePort>`. You can also switch to `hostNetwork=true` (not recommended) or deploy MetalLB to get a LoadBalancer IP.
 
@@ -54,6 +69,8 @@ Then patch the ingress Service to `LoadBalancer`:
 kubectl -n ingress-nginx patch svc ingress-nginx-controller -p '{"spec":{"type":"LoadBalancer"}}'
 ```
 
+Verify that `EXTERNAL-IP` is assigned from the configured pool.
+
 ## 3) Sample Ingress for the demo (host‑based)
 
 Assuming you expose the FastAPI demo behind a Service (or you port‑forward it), you can define an Ingress for path routing.
@@ -85,6 +102,96 @@ Notes:
 - For local testing, add `swe.local` to `/etc/hosts` pointing to the node IP.
 - If you run the frontend outside the cluster, prefer port‑forward and skip Ingress for the web until it’s packaged as a Service.
 
+Create a Service for the frontend (if you package the demo in‑cluster):
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-frontend
+  namespace: swe
+spec:
+  selector:
+    app: demo-frontend
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+```
+
+Smoke tests:
+
+```bash
+# NodePort (no MetalLB)
+curl -sS http://<NODE_IP>:<NODEPORT>/ -I | head -n 1
+
+# Ingress (resolving swe.local)
+curl -sS http://swe.local/ -I | head -n 1
+```
+
+## 6) Local access without exposing the cluster (port‑forward)
+
+For lab setups without MetalLB or external exposure, you can reach the Ingress Controller locally via port‑forward.
+
+### 6.1 /etc/hosts entries
+
+Add hostnames to your local `/etc/hosts` so browser and curl resolve to localhost:
+
+```bash
+sudo sh -c 'printf "\n127.0.0.1 swe-ai-fleet.local\n127.0.0.1 demo.swe-ia-fleet.local\n" >> /etc/hosts'
+```
+
+These hostnames must match the `spec.rules[].host` values in your Ingress objects.
+
+### 6.2 Port‑forward with sudo using your kubeconfig
+
+When binding to privileged port 80, use sudo and pass your kubeconfig explicitly:
+
+```bash
+# Option A: set KUBECONFIG inline
+sudo KUBECONFIG=/home/ia/.kube/config \
+  kubectl -n ingress-nginx port-forward svc/ingress-nginx-controller 80:80
+
+# Option B: preserve env with -E
+export KUBECONFIG=/home/ia/.kube/config
+sudo -E kubectl -n ingress-nginx port-forward svc/ingress-nginx-controller 80:80
+```
+
+Open another terminal and verify:
+
+```bash
+curl -s -H 'Host: swe-ai-fleet.local' http://127.0.0.1/ | cat
+curl -s -H 'Host: demo.swe-ia-fleet.local' http://127.0.0.1/ | cat
+```
+
+Expected output for the demo echo service:
+
+```
+hello swe-ai-fleet from kubernetes!!
+```
+
+### 6.3 Alternative (non‑root) using high port
+
+If you prefer avoiding sudo, forward to a high local port and use that on curl/browser:
+
+```bash
+kubectl -n ingress-nginx port-forward svc/ingress-nginx-controller 8080:80 --address 127.0.0.1
+
+curl -s -H 'Host: swe-ai-fleet.local' http://127.0.0.1:8080/
+```
+
+### 6.4 Common issues
+
+- Connection refused on `kubectl port-forward` with sudo:
+  - Ensure the effective kubeconfig is set: `sudo env | grep KUBECONFIG` should reflect `/home/ia/.kube/config`.
+  - Use `sudo -E` or inline `KUBECONFIG=...` as above.
+- 404 from default backend:
+  - Confirm Ingress exists, `ingressClassName: nginx`, and host/path match the Service name/port.
+- Host headers not routed:
+  - Verify `/etc/hosts` entries and that you curl with `-H 'Host: <name>'`.
+- Nothing on curl but pod healthy:
+  - Check `kubectl -n ingress-nginx get pods,svc` and `describe ingress` for errors.
+
 ## 4) TLS (optional)
 
 Use cert-manager for automated TLS. For lab use, self‑signed is fine.
@@ -100,3 +207,19 @@ helm upgrade --install cert-manager jetstack/cert-manager \
 ```
 
 Then define an Issuer/ClusterIssuer and annotate your Ingress with `cert-manager.io/cluster-issuer: <name>`.
+
+## 5) Troubleshooting
+
+- `EXTERNAL-IP <pending>` on `ingress-nginx-controller`:
+  - Install MetalLB and configure an `IPAddressPool`.
+  - Alternatively, use NodePort for local access.
+
+- 404 from default backend:
+  - Ensure `ingressClassName: nginx` and path rules target the correct Service name/port.
+
+- NodePort connection refused:
+  - Check host firewall (open NodePorts).
+  - Confirm `kube-proxy` without iptables/ipvs errors.
+
+- Hostname resolution (swe.local):
+  - Add `/etc/hosts` entry mapping to node IP or MetalLB `EXTERNAL-IP`.

--- a/docs/INGRESS_INSTALL.md
+++ b/docs/INGRESS_INSTALL.md
@@ -1,0 +1,102 @@
+# Ingress Controller Install (NGINX) — kubeadm + CRI‑O
+
+This guide installs the community NGINX Ingress Controller on a kubeadm cluster.
+
+## 1) Install Ingress NGINX via Helm (recommended)
+
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+
+kubectl create namespace ingress-nginx || true
+
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  -n ingress-nginx \
+  --set controller.watchIngressWithoutClass=true \
+  --set controller.admissionWebhooks.enabled=true
+
+kubectl get pods -n ingress-nginx -o wide
+kubectl get svc -n ingress-nginx
+```
+
+Note:
+- On bare‑metal, the default Service is a `NodePort`. For a single‑node lab, access via `http://<nodeIP>:<nodePort>`. You can also switch to `hostNetwork=true` (not recommended) or deploy MetalLB to get a LoadBalancer IP.
+
+## 2) Bare‑metal: MetalLB (optional)
+
+```bash
+helm repo add metallb https://metallb.github.io/metallb
+helm repo update
+kubectl create namespace metallb-system || true
+helm upgrade --install metallb metallb/metallb -n metallb-system
+
+# Create an address pool (example CIDR)
+cat <<'EOF' | kubectl apply -n metallb-system -f -
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+spec:
+  addresses:
+  - 192.168.1.240-192.168.1.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default-l2
+spec: {}
+EOF
+```
+
+Then patch the ingress Service to `LoadBalancer`:
+
+```bash
+kubectl -n ingress-nginx patch svc ingress-nginx-controller -p '{"spec":{"type":"LoadBalancer"}}'
+```
+
+## 3) Sample Ingress for the demo (host‑based)
+
+Assuming you expose the FastAPI demo behind a Service (or you port‑forward it), you can define an Ingress for path routing.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: swe-demo
+  namespace: swe
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: swe.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: demo-frontend
+            port:
+              number: 8080
+```
+
+Notes:
+- For local testing, add `swe.local` to `/etc/hosts` pointing to the node IP.
+- If you run the frontend outside the cluster, prefer port‑forward and skip Ingress for the web until it’s packaged as a Service.
+
+## 4) TLS (optional)
+
+Use cert-manager for automated TLS. For lab use, self‑signed is fine.
+
+```bash
+# Install cert-manager
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+kubectl create namespace cert-manager || true
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --set installCRDs=true
+```
+
+Then define an Issuer/ClusterIssuer and annotate your Ingress with `cert-manager.io/cluster-issuer: <name>`.

--- a/docs/INSTALL_K8S_CRIO_GPU.md
+++ b/docs/INSTALL_K8S_CRIO_GPU.md
@@ -2,6 +2,30 @@
 
 Esta guía describe cómo instalar un clúster de Kubernetes usando CRI‑O como runtime de contenedores y habilitar GPUs NVIDIA mediante el NVIDIA GPU Operator. Está orientada a una estación Linux (ej. Arch Linux) pero incluye notas para otras distros.
 
+## Estrategia de instalación — por qué instalar primero las herramientas de Kubernetes
+
+Antes de inicializar el clúster, instalamos primero las herramientas base de Kubernetes (kubeadm, kubelet, kubectl) y Helm por los siguientes motivos:
+
+- Dependencias previas: `kubeadm` y `kubelet` son necesarios para el `init` del plano de control y para gestionar el servicio de nodo.
+- Servicio persistente: habilitar `kubelet` de antemano evita pasos adicionales tras el `init` y facilita diagnósticos si algo falla.
+- Helm como estándar: el NVIDIA GPU Operator, Ingress NGINX y otros componentes se instalan cómodamente con Helm; tenerlo listo simplifica el flujo.
+- Idempotencia y bajo riesgo: la instalación de binarios no modifica el estado del clúster; es segura de ejecutar incluso si la inicialización se difiere.
+- Trazabilidad y soporte: confirmar versiones (kubeadm/kubectl/helm) al inicio reduce variables en la resolución de problemas.
+
+Comandos ejecutados (Arch Linux):
+
+```bash
+sudo pacman -S --noconfirm kubeadm kubelet kubectl helm
+sudo systemctl enable --now kubelet
+
+# Verificar versiones
+kubeadm version -o short
+kubectl version --client
+helm version --short
+```
+
+> Importante: hasta este punto solo hemos instalado y habilitado las herramientas. **Aún NO hemos configurado/inicializado el clúster** (no se ha ejecutado `kubeadm init`). La configuración del clúster comienza en el siguiente apartado.
+
 ## Requisitos
 
 - Host Linux con privilegios de administrador

--- a/docs/K8S_DEMO_RUNBOOK.md
+++ b/docs/K8S_DEMO_RUNBOOK.md
@@ -1,0 +1,182 @@
+# Kubernetes Demo Runbook (Kubeadm + CRI‑O + GPU Operator)
+
+This runbook executes the installation (post‑cluster) and runs the demo on Kubernetes. It assumes you have a kubeadm cluster with CRI‑O and (optionally) the NVIDIA GPU Operator installed per `docs/INSTALL_K8S_CRIO_GPU.md`.
+
+## Architecture (ASCII)
+
+```
+               +-----------------------------+
+               |        Ingress (NGINX)      |
+               |     ingress-nginx namespace |
+               +---------------+-------------+
+                               |
+                         Host: swe.local
+                               |
+                     +---------v----------+
+                     |  Service: demo-web |   (optional when web runs in-cluster)
+                     |     swe namespace   |
+                     +---------+----------+
+                               |
+                         +-----v-----+
+                         |   Pod:    |
+                         |   web     |  FastAPI demo (UI/API)
+                         +-----+-----+
+                               |
+        +----------------------+-----------------------+
+        |                      |                       |
+        v                      v                       v
+ +------+-------+      +-------+------+        +-------+------+
+ | Service:     |      | Service:     |        | Service:     |
+ | redis        |      | neo4j        |        | vllm         |  (GPU)
+ +------+-------+      +-------+------+        +-------+------+
+        |                      |                       |
+   +----v----+            +----v----+            +-----v-----+
+   |  Pod:   |            |  Pod:   |            |   Pod:    |
+   |  redis  |            |  neo4j  |            |  vllm     |
+   +---------+            +---------+            +-----------+
+        ^                                               ^
+        |                                               |
+    Secret:                                         GPU Operator
+  redis-auth                                        (nvidia.com/gpu)
+                                                     + CDI devices
+
+Notes:
+- Namespace: `swe` for demo services; `ingress-nginx` for Ingress Controller.
+- Secrets: `redis-auth`, `neo4j-auth` in `swe` namespace.
+- vLLM schedules on GPU nodes (NVIDIA GPU Operator installed) and exposes `nvidia.com/gpu` resources.
+- For local iteration, the web can run outside the cluster; use port-forward to Redis/Neo4j Services.
+```
+
+## Prerequisites
+
+- Working Kubernetes cluster (kubeadm) with CRI‑O
+- CNI installed (e.g., Calico)
+- kubectl and helm configured to the cluster
+- Optional: GPU nodes with NVIDIA GPU Operator (for vLLM)
+ - Ingress Controller (NGINX). See `docs/INGRESS_INSTALL.md`.
+
+## 1) Namespace and Secrets
+
+```bash
+kubectl create namespace swe || true
+
+# Redis password secret
+kubectl -n swe create secret generic redis-auth \
+  --from-literal=password=swefleet-dev || true
+
+# Neo4j password secret
+kubectl -n swe create secret generic neo4j-auth \
+  --from-literal=password=swefleet-dev || true
+```
+
+## 2) Helm install base services (Redis, Neo4j; vLLM optional)
+
+```bash
+helm dependency update deploy/helm || true
+helm upgrade --install swe-fleet deploy/helm -n swe --create-namespace
+
+kubectl get pods -n swe -o wide
+kubectl get svc -n swe
+```
+
+Values reference (`deploy/helm/values.yaml`):
+- `redis.host`: `redis.default.svc` (will resolve as `redis.swe.svc` by namespace)
+- `neo4j.boltUri`: `bolt://neo4j.swe.svc:7687`
+- `neo4j.httpUri`: `http://neo4j.swe.svc:7474`
+- `vllm.enabled`: set to `true` when GPU nodes available; confirm GPU Operator status
+
+Enable vLLM (GPU) later with:
+
+```bash
+helm upgrade swe-fleet deploy/helm -n swe \
+  --set vllm.enabled=true \
+  --set vllm.gpu.nvidia=true \
+  --set vllm.gpu.numDevices=1
+```
+
+## 3) Port‑forward for local seeding
+
+For local scripts to reach in‑cluster services without exposing services externally:
+
+```bash
+# In separate terminals
+kubectl -n swe port-forward svc/redis 6379:6379
+kubectl -n swe port-forward svc/neo4j 7474:7474
+kubectl -n swe port-forward svc/neo4j 7687:7687
+```
+
+## 4) Seed demo data (CTX‑001)
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -U pip
+pip install -e .
+
+export REDIS_URL=redis://:swefleet-dev@localhost:6379/0
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=swefleet-dev
+export DEMO_CASE_ID=CTX-001
+
+python scripts/seed_context_example.py
+```
+
+Verification (optional):
+
+```bash
+# Decisions, influenced subtasks, and authors
+kubectl -n swe exec -it deploy/neo4j -- \
+  /var/lib/neo4j/bin/cypher-shell -u neo4j -p "$NEO4J_PASSWORD" \
+  "MATCH (c:Case {id:'CTX-001'})-[:HAS_PLAN]->(:PlanVersion)-[:CONTAINS_DECISION]->(d:Decision)\n   OPTIONAL MATCH (d)-[:INFLUENCES]->(s:Subtask)\n   OPTIONAL MATCH (d)-[:AUTHORED_BY]->(a:Actor)\n   RETURN d.id, collect(DISTINCT s.id), collect(DISTINCT a.id) ORDER BY d.id;"
+```
+
+## 5) Run the demo frontend locally
+
+```bash
+pip install -e .[web]
+HOST=0.0.0.0 PORT=8080 \
+REDIS_URL=redis://:swefleet-dev@localhost:6379/0 \
+NEO4J_URI=bolt://localhost:7687 NEO4J_USER=neo4j NEO4J_PASSWORD=swefleet-dev \
+swe_ai_fleet-web
+```
+
+Open:
+- UI: `http://localhost:8080/ui/report?case_id=CTX-001`
+- API: `http://localhost:8080/api/report?case_id=CTX-001&persist=false`
+
+## 6) Optional: Deploy vLLM and test health
+
+Enable vLLM via Helm (see step 2), then:
+
+```bash
+kubectl -n swe port-forward svc/vllm 8000:8000
+curl -fsS http://127.0.0.1:8000/health && echo ok
+curl -sS http://127.0.0.1:8000/v1/models | jq .
+```
+
+Point the demo to vLLM:
+
+```bash
+export LLM_BACKEND=vllm
+export VLLM_ENDPOINT=http://127.0.0.1:8000/v1
+export VLLM_MODEL=TinyLlama/TinyLlama-1.1B-Chat-v1.0
+```
+
+## 7) Troubleshooting
+
+- Secrets mismatch → Neo4j/Redis auth failures: recreate secrets and restart pods.
+- Port‑forward conflicts → free the ports or use alternate local ports.
+- vLLM not scheduling → confirm GPU Operator pods Running and node allocatable `nvidia.com/gpu`.
+- DNS in scripts: favor port‑forward with localhost rather than direct Service DNS from host.
+
+## 8) Cleanup
+
+```bash
+helm uninstall swe-fleet -n swe || true
+kubectl delete ns swe || true
+```
+
+## Notes
+
+- This runbook keeps the frontend local to simplify iteration; a future chart will package the web service for in‑cluster deployment.
+- For production‑like exposure, use Ingress/Gateway and configure secrets via sealed secrets or external secret managers.

--- a/k8s_calico_diag.log
+++ b/k8s_calico_diag.log
@@ -1,0 +1,581 @@
+
+===== Environment =====
++ kubectl version --client || true
+Client Version: v1.33.4
+Kustomize Version: v5.6.0
++ crio --version || true
+crio version 1.33.4
+   GitCommit:      unknown
+   GitCommitDate:  unknown
+   GitTreeState:   clean
+   BuildDate:      2025-09-02T11:28:42Z
+   GoVersion:      go1.24.6
+   Compiler:       gc
+   Platform:       linux/amd64
+   Linkmode:       dynamic
+   BuildTags:
+     containers_image_ostree_stub
+     apparmor
+     seccomp
+   LDFlags:           -X github.com/cri-o/cri-o/internal/version.buildDate=2025-09-02T11:28:42Z -compressdwarf=false -linkmode external
+   SeccompEnabled:   true
+   AppArmorEnabled:  false
+
+===== Nodes =====
++ kubectl get nodes -o wide
+NAME          STATUS   ROLES           AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME
+worker-node   Ready    control-plane   22m   v1.33.4   192.168.1.46   <none>        Arch Linux   6.16.6-arch1-1   cri-o://1.33.4
+
+===== kube-system pods (Calico, CoreDNS, control plane) =====
++ kubectl -n kube-system get pods -o wide | grep -E 'calico|coredns|kube-|etcd' || true
+calico-kube-controllers-d4544f494-f27zr   0/1     CrashLoopBackOff        8 (4m4s ago)   21m     10.88.0.4      worker-node   <none>           <none>
+calico-node-dqwwv                         0/1     Init:CrashLoopBackOff   4 (42s ago)    4m48s   192.168.1.46   worker-node   <none>           <none>
+coredns-674b8bbfcf-d9j48                  0/1     CrashLoopBackOff        6 (24s ago)    13m     127.0.0.1      worker-node   <none>           <none>
+coredns-674b8bbfcf-q8bhd                  0/1     CrashLoopBackOff        6 (34s ago)    13m     127.0.0.1      worker-node   <none>           <none>
+etcd-worker-node                          1/1     Running                 0              22m     192.168.1.46   worker-node   <none>           <none>
+kube-apiserver-worker-node                1/1     Running                 0              22m     192.168.1.46   worker-node   <none>           <none>
+kube-controller-manager-worker-node       1/1     Running                 0              22m     192.168.1.46   worker-node   <none>           <none>
+kube-proxy-24lnm                          1/1     Running                 0              22m     192.168.1.46   worker-node   <none>           <none>
+kube-scheduler-worker-node                1/1     Running                 0              22m     192.168.1.46   worker-node   <none>           <none>
+
+===== Calico DaemonSet and Deployment =====
++ kubectl -n kube-system get ds calico-node -o wide || true
+NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE   CONTAINERS    IMAGES                          SELECTOR
+calico-node   1         1         0       1            0           kubernetes.io/os=linux   21m   calico-node   docker.io/calico/node:v3.27.3   k8s-app=calico-node
++ kubectl -n kube-system get deploy calico-kube-controllers -o wide || true
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS                IMAGES                                      SELECTOR
+calico-kube-controllers   0/1     1            0           21m   calico-kube-controllers   docker.io/calico/kube-controllers:v3.27.3   k8s-app=calico-kube-controllers
+
+===== kube-system recent events =====
++ kubectl -n kube-system get events --sort-by=.lastTimestamp | tail -n 50
+13m         Normal    SuccessfulDelete               daemonset/calico-node                          Deleted pod: calico-node-9g8nm
+13m         Normal    SuccessfulCreate               replicaset/coredns-674b8bbfcf                  Created pod: coredns-674b8bbfcf-q8bhd
+13m         Normal    SuccessfulCreate               replicaset/coredns-674b8bbfcf                  Created pod: coredns-674b8bbfcf-d9j48
+13m         Normal    Started                        pod/calico-node-78p4k                          Started container upgrade-ipam
+13m         Normal    Scheduled                      pod/calico-node-78p4k                          Successfully assigned kube-system/calico-node-78p4k to worker-node
+13m         Normal    Pulled                         pod/calico-node-78p4k                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+13m         Normal    Created                        pod/calico-node-78p4k                          Created container: upgrade-ipam
+13m         Normal    Killing                        pod/coredns-674b8bbfcf-cwm9h                   Stopping container coredns
+13m         Normal    Scheduled                      pod/calico-node-9g8nm                          Successfully assigned kube-system/calico-node-9g8nm to worker-node
+13m         Warning   FailedMount                    pod/calico-node-9g8nm                          MountVolume.SetUp failed for volume "kube-api-access-ngkh6" : failed to fetch token: pod "calico-node-9g8nm" not found
+13m         Normal    Killing                        pod/coredns-674b8bbfcf-b5g4j                   Stopping container coredns
+13m         Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: endpoints[2].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)
+13m         Warning   FailedToUpdateEndpoint         endpoints/kube-dns                             Failed to update endpoint kube-system/kube-dns: Endpoints "kube-dns" is invalid: subsets[0].notReadyAddresses[0].ip: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)
+13m         Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: [endpoints[2].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), endpoints[3].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+13m         Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: [endpoints[1].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), endpoints[2].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+13m         Warning   FailedToUpdateEndpoint         endpoints/kube-dns                             Failed to update endpoint kube-system/kube-dns: Endpoints "kube-dns" is invalid: [subsets[0].notReadyAddresses[0].ip: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), subsets[0].notReadyAddresses[1].ip: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+11m         Warning   Unhealthy                      pod/coredns-674b8bbfcf-q8bhd                   Liveness probe failed: Get "http://127.0.0.1:8080/health": dial tcp 127.0.0.1:8080: connect: connection refused
+11m         Warning   Unhealthy                      pod/coredns-674b8bbfcf-d9j48                   Liveness probe failed: Get "http://127.0.0.1:8080/health": dial tcp 127.0.0.1:8080: connect: connection refused
+10m         Warning   Unhealthy                      pod/calico-kube-controllers-d4544f494-f27zr    Readiness probe failed: Error initializing datastore: Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+7m52s       Normal    Started                        pod/calico-node-78p4k                          Started container install-cni
+7m52s       Normal    Pulled                         pod/calico-node-78p4k                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+7m52s       Normal    Created                        pod/calico-node-78p4k                          Created container: install-cni
+5m24s       Normal    Pulled                         pod/calico-kube-controllers-d4544f494-f27zr    Container image "docker.io/calico/kube-controllers:v3.27.3" already present on machine
+5m24s       Normal    Started                        pod/calico-kube-controllers-d4544f494-f27zr    Started container calico-kube-controllers
+5m24s       Normal    Created                        pod/calico-kube-controllers-d4544f494-f27zr    Created container: calico-kube-controllers
+4m59s       Warning   BackOff                        pod/calico-node-78p4k                          Back-off restarting failed container install-cni in pod calico-node-78p4k_kube-system(820a1a6a-9267-400a-a1e9-ac24ae46847d)
+4m48s       Normal    Created                        pod/calico-node-dqwwv                          Created container: upgrade-ipam
+4m48s       Normal    Scheduled                      pod/calico-node-dqwwv                          Successfully assigned kube-system/calico-node-dqwwv to worker-node
+4m48s       Normal    SuccessfulDelete               daemonset/calico-node                          Deleted pod: calico-node-78p4k
+4m48s       Normal    SuccessfulCreate               daemonset/calico-node                          Created pod: calico-node-wjb6l
+4m48s       Normal    SuccessfulCreate               daemonset/calico-node                          Created pod: calico-node-dqwwv
+4m48s       Normal    Started                        pod/calico-node-dqwwv                          Started container upgrade-ipam
+4m48s       Normal    Scheduled                      pod/calico-node-wjb6l                          Successfully assigned kube-system/calico-node-wjb6l to worker-node
+4m48s       Normal    Pulled                         pod/calico-node-dqwwv                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+4m41s       Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: [endpoints[0].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), endpoints[1].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+3m12s       Warning   Unhealthy                      pod/coredns-674b8bbfcf-d9j48                   Readiness probe failed: Get "http://127.0.0.1:8181/ready": dial tcp 127.0.0.1:8181: connect: connection refused
+3m12s       Warning   Unhealthy                      pod/coredns-674b8bbfcf-q8bhd                   Readiness probe failed: Get "http://127.0.0.1:8181/ready": dial tcp 127.0.0.1:8181: connect: connection refused
+2m29s       Normal    Killing                        pod/coredns-674b8bbfcf-q8bhd                   Container coredns failed liveness probe, will be restarted
+2m23s       Normal    Pulled                         pod/coredns-674b8bbfcf-q8bhd                   Container image "registry.k8s.io/coredns/coredns:v1.12.0" already present on machine
+2m23s       Normal    Started                        pod/coredns-674b8bbfcf-q8bhd                   Started container coredns
+2m23s       Normal    Created                        pod/coredns-674b8bbfcf-q8bhd                   Created container: coredns
+2m19s       Normal    Killing                        pod/coredns-674b8bbfcf-d9j48                   Container coredns failed liveness probe, will be restarted
+2m13s       Normal    Started                        pod/coredns-674b8bbfcf-d9j48                   Started container coredns
+2m13s       Normal    Created                        pod/coredns-674b8bbfcf-d9j48                   Created container: coredns
+2m13s       Normal    Pulled                         pod/coredns-674b8bbfcf-d9j48                   Container image "registry.k8s.io/coredns/coredns:v1.12.0" already present on machine
+72s         Normal    Pulled                         pod/calico-node-dqwwv                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+72s         Normal    Created                        pod/calico-node-dqwwv                          Created container: install-cni
+72s         Normal    Started                        pod/calico-node-dqwwv                          Started container install-cni
+40s         Warning   BackOff                        pod/calico-kube-controllers-d4544f494-f27zr    Back-off restarting failed container calico-kube-controllers in pod calico-kube-controllers-d4544f494-f27zr_kube-system(6be8928d-a3c1-40f7-81ac-1b03b4f92d80)
+0s          Warning   BackOff                        pod/calico-node-dqwwv                          Back-off restarting failed container install-cni in pod calico-node-dqwwv_kube-system(71d2ed41-09ea-460a-82ad-f3b2d78d0112)
+
+===== Describe calico-node pod: calico-node-dqwwv =====
++ kubectl -n kube-system describe pod calico-node-dqwwv | sed -n '1,200p'
+Name:                 calico-node-dqwwv
+Namespace:            kube-system
+Priority:             2000001000
+Priority Class Name:  system-node-critical
+Service Account:      calico-node
+Node:                 worker-node/192.168.1.46
+Start Time:           Sat, 13 Sep 2025 12:24:00 +0000
+Labels:               controller-revision-hash=6f86f5ff8b
+                      k8s-app=calico-node
+                      pod-template-generation=4
+Annotations:          kubectl.kubernetes.io/restartedAt: 2025-09-13T12:24:00Z
+Status:               Pending
+IP:                   192.168.1.46
+IPs:
+  IP:           192.168.1.46
+Controlled By:  DaemonSet/calico-node
+Init Containers:
+  upgrade-ipam:
+    Container ID:  cri-o://951d9b7ad777eee460def1d4e9a4b0741abc23849fd733a30e7126d8a2d2d4f8
+    Image:         docker.io/calico/cni:v3.27.3
+    Image ID:      docker.io/calico/cni@sha256:1f2c6a13d436b2ae056edd46552d23279d3aaf5d79152fb88cd959b634acfd6f
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      /opt/cni/bin/calico-ipam
+      -upgrade
+    State:          Terminated
+      Reason:       Completed
+      Exit Code:    0
+      Started:      Sat, 13 Sep 2025 12:24:00 +0000
+      Finished:     Sat, 13 Sep 2025 12:24:00 +0000
+    Ready:          True
+    Restart Count:  0
+    Environment Variables from:
+      kubernetes-services-endpoint  ConfigMap  Optional: true
+    Environment:
+      KUBERNETES_NODE_NAME:        (v1:spec.nodeName)
+      CALICO_NETWORKING_BACKEND:  <set to the key 'calico_backend' of config map 'calico-config'>  Optional: false
+      CALICO_IPV4POOL_CIDR:       10.244.0.0/16
+    Mounts:
+      /host/opt/cni/bin from cni-bin-dir (rw)
+      /var/lib/cni/networks from host-local-net-dir (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+  install-cni:
+    Container ID:  cri-o://af4cda100db45347053d598b98f88aeb881ff60b8b958977e0ea0eb031bdf29e
+    Image:         docker.io/calico/cni:v3.27.3
+    Image ID:      docker.io/calico/cni@sha256:1f2c6a13d436b2ae056edd46552d23279d3aaf5d79152fb88cd959b634acfd6f
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      /opt/cni/bin/install
+    State:          Waiting
+      Reason:       CrashLoopBackOff
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    1
+      Started:      Sat, 13 Sep 2025 12:27:36 +0000
+      Finished:     Sat, 13 Sep 2025 12:28:06 +0000
+    Ready:          False
+    Restart Count:  4
+    Environment Variables from:
+      kubernetes-services-endpoint  ConfigMap  Optional: true
+    Environment:
+      CNI_CONF_NAME:         10-calico.conflist
+      CNI_NETWORK_CONFIG:    <set to the key 'cni_network_config' of config map 'calico-config'>  Optional: false
+      KUBERNETES_NODE_NAME:   (v1:spec.nodeName)
+      CNI_MTU:               <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      SLEEP:                 false
+      CALICO_IPV4POOL_CIDR:  10.244.0.0/16
+    Mounts:
+      /host/etc/cni/net.d from cni-net-dir (rw)
+      /host/opt/cni/bin from cni-bin-dir (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+  mount-bpffs:
+    Container ID:  
+    Image:         docker.io/calico/node:v3.27.3
+    Image ID:      
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      calico-node
+      -init
+      -best-effort
+    State:          Waiting
+      Reason:       PodInitializing
+    Ready:          False
+    Restart Count:  0
+    Environment:
+      CALICO_IPV4POOL_CIDR:  10.244.0.0/16
+    Mounts:
+      /nodeproc from nodeproc (ro)
+      /sys/fs from sys-fs (rw)
+      /var/run/calico from var-run-calico (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+Containers:
+  calico-node:
+    Container ID:   
+    Image:          docker.io/calico/node:v3.27.3
+    Image ID:       
+    Port:           <none>
+    Host Port:      <none>
+    State:          Waiting
+      Reason:       PodInitializing
+    Ready:          False
+    Restart Count:  0
+    Requests:
+      cpu:      250m
+    Liveness:   exec [/bin/calico-node -felix-live -bird-live] delay=10s timeout=10s period=10s #success=1 #failure=6
+    Readiness:  exec [/bin/calico-node -felix-ready -bird-ready] delay=0s timeout=10s period=10s #success=1 #failure=3
+    Environment Variables from:
+      kubernetes-services-endpoint  ConfigMap  Optional: true
+    Environment:
+      DATASTORE_TYPE:                     kubernetes
+      WAIT_FOR_DATASTORE:                 true
+      NODENAME:                            (v1:spec.nodeName)
+      CALICO_NETWORKING_BACKEND:          <set to the key 'calico_backend' of config map 'calico-config'>  Optional: false
+      CLUSTER_TYPE:                       k8s,bgp
+      IP:                                 autodetect
+      CALICO_IPV4POOL_IPIP:               Always
+      CALICO_IPV4POOL_VXLAN:              Never
+      CALICO_IPV6POOL_VXLAN:              Never
+      FELIX_IPINIPMTU:                    <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      FELIX_VXLANMTU:                     <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      FELIX_WIREGUARDMTU:                 <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      CALICO_DISABLE_FILE_LOGGING:        true
+      FELIX_DEFAULTENDPOINTTOHOSTACTION:  ACCEPT
+      FELIX_IPV6SUPPORT:                  false
+      FELIX_HEALTHENABLED:                true
+      CALICO_IPV4POOL_CIDR:               10.244.0.0/16
+    Mounts:
+      /host/etc/cni/net.d from cni-net-dir (rw)
+      /lib/modules from lib-modules (ro)
+      /run/xtables.lock from xtables-lock (rw)
+      /sys/fs/bpf from bpffs (rw)
+      /var/lib/calico from var-lib-calico (rw)
+      /var/log/calico/cni from cni-log-dir (ro)
+      /var/run/calico from var-run-calico (rw)
+      /var/run/nodeagent from policysync (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+Conditions:
+  Type                        Status
+  PodReadyToStartContainers   True 
+  Initialized                 False 
+  Ready                       False 
+  ContainersReady             False 
+  PodScheduled                True 
+Volumes:
+  lib-modules:
+    Type:          HostPath (bare host directory volume)
+    Path:          /lib/modules
+    HostPathType:  
+  var-run-calico:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/run/calico
+    HostPathType:  
+  var-lib-calico:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/lib/calico
+    HostPathType:  
+  xtables-lock:
+    Type:          HostPath (bare host directory volume)
+    Path:          /run/xtables.lock
+    HostPathType:  FileOrCreate
+  sys-fs:
+    Type:          HostPath (bare host directory volume)
+    Path:          /sys/fs/
+    HostPathType:  DirectoryOrCreate
+  bpffs:
+    Type:          HostPath (bare host directory volume)
+    Path:          /sys/fs/bpf
+    HostPathType:  Directory
+  nodeproc:
+    Type:          HostPath (bare host directory volume)
+    Path:          /proc
+    HostPathType:  
+  cni-bin-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /opt/cni/bin
+    HostPathType:  
+  cni-net-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /etc/cni/net.d
+    HostPathType:  
+  cni-log-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/log/calico/cni
+    HostPathType:  
+  host-local-net-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/lib/cni/networks
+    HostPathType:  
+  policysync:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/run/nodeagent
+    HostPathType:  DirectoryOrCreate
+  kube-api-access-gpgdm:
+    Type:                    Projected (a volume that contains injected data from multiple sources)
+    TokenExpirationSeconds:  3607
+    ConfigMapName:           kube-root-ca.crt
+    Optional:                false
+
+===== Logs: calico-node init container install-cni (tail) =====
++ kubectl -n kube-system logs calico-node-dqwwv -c install-cni --tail=200
+2025-09-13 12:27:36.089 [INFO][1] cni-installer/<nil> <nil>: Running as a Kubernetes pod
+2025-09-13 12:27:36.091 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/bandwidth"
+2025-09-13 12:27:36.091 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/bandwidth
+2025-09-13 12:27:36.125 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/calico"
+2025-09-13 12:27:36.125 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/calico
+2025-09-13 12:27:36.156 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/calico-ipam"
+2025-09-13 12:27:36.156 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/calico-ipam
+2025-09-13 12:27:36.158 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/flannel"
+2025-09-13 12:27:36.158 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/flannel
+2025-09-13 12:27:36.160 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/host-local"
+2025-09-13 12:27:36.160 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/host-local
+2025-09-13 12:27:36.162 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/loopback"
+2025-09-13 12:27:36.162 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/loopback
+2025-09-13 12:27:36.165 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/portmap"
+2025-09-13 12:27:36.165 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/portmap
+2025-09-13 12:27:36.167 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/tuning"
+2025-09-13 12:27:36.167 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/tuning
+2025-09-13 12:27:36.167 [INFO][1] cni-installer/<nil> <nil>: Wrote Calico CNI binaries to /host/opt/cni/bin
+
+2025-09-13 12:27:36.201 [INFO][1] cni-installer/<nil> <nil>: CNI plugin version: v3.27.3
+2025-09-13 12:27:36.201 [INFO][1] cni-installer/<nil> <nil>: /host/secondary-bin-dir is not writeable, skipping
+2025-09-13 12:27:36.201 [WARNING][1] cni-installer/<nil> <nil>: Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
+2025-09-13 12:28:06.230 [ERROR][1] cni-installer/<nil> <nil>: Unable to create token for CNI kubeconfig error=Post "https://10.96.0.1:443/api/v1/namespaces/kube-system/serviceaccounts/calico-cni-plugin/token": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:28:06.230 [FATAL][1] cni-installer/<nil> <nil>: Unable to create token for CNI kubeconfig error=Post "https://10.96.0.1:443/api/v1/namespaces/kube-system/serviceaccounts/calico-cni-plugin/token": dial tcp 10.96.0.1:443: i/o timeout
+
+===== Logs: calico-node main container (tail) =====
++ kubectl -n kube-system logs calico-node-dqwwv -c calico-node --tail=200
+Error from server (BadRequest): container "calico-node" in pod "calico-node-dqwwv" is waiting to start: PodInitializing
+
+===== Describe calico-kube-controllers pod: calico-kube-controllers-d4544f494-f27zr =====
++ kubectl -n kube-system describe pod calico-kube-controllers-d4544f494-f27zr | sed -n '1,200p'
+Name:                 calico-kube-controllers-d4544f494-f27zr
+Namespace:            kube-system
+Priority:             2000000000
+Priority Class Name:  system-cluster-critical
+Service Account:      calico-kube-controllers
+Node:                 worker-node/192.168.1.46
+Start Time:           Sat, 13 Sep 2025 12:07:43 +0000
+Labels:               k8s-app=calico-kube-controllers
+                      pod-template-hash=d4544f494
+Annotations:          <none>
+Status:               Running
+IP:                   10.88.0.4
+IPs:
+  IP:           10.88.0.4
+Controlled By:  ReplicaSet/calico-kube-controllers-d4544f494
+Containers:
+  calico-kube-controllers:
+    Container ID:   cri-o://aca84ceaa326548df1abc6debf2853ccf188cec0bc0a53797d19417ac5d0d0a7
+    Image:          docker.io/calico/kube-controllers:v3.27.3
+    Image ID:       docker.io/calico/kube-controllers@sha256:3e8bc2000187cc71346538aaa8e10cd7941ba75f744e315f48b3a3293399a495
+    Port:           <none>
+    Host Port:      <none>
+    State:          Waiting
+      Reason:       CrashLoopBackOff
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    1
+      Started:      Sat, 13 Sep 2025 12:23:44 +0000
+      Finished:     Sat, 13 Sep 2025 12:24:44 +0000
+    Ready:          False
+    Restart Count:  8
+    Liveness:       exec [/usr/bin/check-status -l] delay=10s timeout=10s period=10s #success=1 #failure=6
+    Readiness:      exec [/usr/bin/check-status -r] delay=0s timeout=1s period=10s #success=1 #failure=3
+    Environment:
+      ENABLED_CONTROLLERS:  node
+      DATASTORE_TYPE:       kubernetes
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-szp9v (ro)
+Conditions:
+  Type                        Status
+  PodReadyToStartContainers   True 
+  Initialized                 True 
+  Ready                       False 
+  ContainersReady             False 
+  PodScheduled                True 
+Volumes:
+  kube-api-access-szp9v:
+    Type:                    Projected (a volume that contains injected data from multiple sources)
+    TokenExpirationSeconds:  3607
+    ConfigMapName:           kube-root-ca.crt
+    Optional:                false
+    DownwardAPI:             true
+QoS Class:                   BestEffort
+Node-Selectors:              kubernetes.io/os=linux
+Tolerations:                 CriticalAddonsOnly op=Exists
+                             node-role.kubernetes.io/control-plane:NoSchedule
+                             node-role.kubernetes.io/master:NoSchedule
+                             node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
+                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
+Events:
+  Type     Reason     Age                  From               Message
+  ----     ------     ----                 ----               -------
+  Normal   Pulling    21m                  kubelet            Pulling image "docker.io/calico/kube-controllers:v3.27.3"
+  Normal   Scheduled  21m                  default-scheduler  Successfully assigned kube-system/calico-kube-controllers-d4544f494-f27zr to worker-node
+  Normal   Pulled     20m                  kubelet            Successfully pulled image "docker.io/calico/kube-controllers:v3.27.3" in 4.652s (11.963s including waiting). Image size: 75746522 bytes.
+  Warning  Unhealthy  19m                  kubelet            Readiness probe errored and resulted in unknown state: rpc error: code = Unknown desc = command error: cannot register an exec PID: container is stopping, stdout: , stderr: , exit code -1
+  Warning  Unhealthy  19m (x11 over 20m)   kubelet            Readiness probe failed: initialized to false
+  Warning  Unhealthy  19m (x5 over 20m)    kubelet            Liveness probe failed: initialized to false
+  Warning  Unhealthy  18m (x4 over 20m)    kubelet            Liveness probe failed: Error initializing datastore: Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+  Normal   Killing    14m (x3 over 19m)    kubelet            Container calico-kube-controllers failed liveness probe, will be restarted
+  Warning  Unhealthy  10m (x11 over 20m)   kubelet            Readiness probe failed: Error initializing datastore: Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+  Normal   Created    5m24s (x8 over 20m)  kubelet            Created container: calico-kube-controllers
+  Normal   Pulled     5m24s (x7 over 19m)  kubelet            Container image "docker.io/calico/kube-controllers:v3.27.3" already present on machine
+  Normal   Started    5m24s (x8 over 20m)  kubelet            Started container calico-kube-controllers
+  Warning  BackOff    40s (x69 over 18m)   kubelet            Back-off restarting failed container calico-kube-controllers in pod calico-kube-controllers-d4544f494-f27zr_kube-system(6be8928d-a3c1-40f7-81ac-1b03b4f92d80)
+
+===== Logs: calico-kube-controllers (tail) =====
++ kubectl -n kube-system logs calico-kube-controllers-d4544f494-f27zr --tail=200
+2025-09-13 12:23:44.037 [INFO][1] main.go 107: Loaded configuration from environment config=&config.Config{LogLevel:"info", WorkloadEndpointWorkers:1, ProfileWorkers:1, PolicyWorkers:1, NodeWorkers:1, Kubeconfig:"", DatastoreType:"kubernetes"}
+2025-09-13 12:23:44.038 [WARNING][1] winutils.go 144: Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
+2025-09-13 12:23:44.038 [INFO][1] main.go 131: Ensuring Calico datastore is initialized
+2025-09-13 12:24:14.038 [ERROR][1] client.go 295: Error getting cluster information config ClusterInformation="default" error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:14.038 [INFO][1] main.go 138: Failed to initialize datastore error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:44.063 [ERROR][1] client.go 295: Error getting cluster information config ClusterInformation="default" error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:44.063 [INFO][1] main.go 138: Failed to initialize datastore error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:44.063 [FATAL][1] main.go 151: Failed to initialize Calico datastore
+
+===== Host CNI directories and configs =====
++ ls -ld /etc/cni/net.d /opt/cni/bin
+drwxr-xr-x 2 root root 4096 sep 13 12:15 /etc/cni/net.d
+drwxr-xr-x 2 root root 4096 sep 13 12:27 /opt/cni/bin
++ ls -l /etc/cni/net.d || true
+total 8
+-rw-r--r-- 1 root root 553 ago 29 17:29 10-crio-bridge.conflist.bak
+-rw-r--r-- 1 root root  61 ago 29 17:00 99-loopback.conf
++ ls -l /opt/cni/bin | egrep 'calico|loopback|host-local|portmap' || true
+egrep: warning: egrep is obsolescent; using grep -E
+-rwxr-xr-x 1 root root 62171883 sep 13 12:07 calico
+-rwxr-xr-x 1 root root 62171883 sep 13 12:07 calico-ipam
+-rwxr-xr-x 1 root root  3522445 sep 13 12:07 host-local
+-rwxr-xr-x 1 root root  3603570 sep 13 12:07 loopback
+-rwxr-xr-x 1 root root  4040630 sep 13 12:07 portmap
+
+===== CNI config: /etc/cni/net.d/10-crio-bridge.conflist.bak =====
++ cat /etc/cni/net.d/10-crio-bridge.conflist.bak
+{
+  "cniVersion": "1.0.0",
+  "name": "crio-bridge",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": false,
+      "hairpinMode": true,
+      "capabilities": { "ips": true },
+      "ipam": {
+        "type": "host-local",
+        "routes": [ { "dst": "0.0.0.0/0" } ],
+        "ranges": [ [ { "subnet": "10.88.0.0/16" } ] ]
+      }
+    },
+    { "type": "firewall" },
+    { "type": "tuning" },
+    { "type": "portmap", "capabilities": { "portMappings": true } }
+  ]
+}
+
+
+===== CNI config: /etc/cni/net.d/99-loopback.conf =====
++ cat /etc/cni/net.d/99-loopback.conf
+{ "cniVersion": "1.0.0", "name": "lo", "type": "loopback" }
+
+
+===== Kernel/sysctl required by CNI =====
++ sysctl net.ipv4.ip_forward || true
+net.ipv4.ip_forward = 1
++ lsmod | grep br_netfilter || true
+br_netfilter           36864  0
+bridge                454656  1 br_netfilter
++ sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables || true
+net.bridge.bridge-nf-call-iptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+
+===== Node detail (taints/conditions/addresses) =====
++ kubectl describe node worker-node | sed -n '1,200p'
+Name:               worker-node
+Roles:              control-plane
+Labels:             beta.kubernetes.io/arch=amd64
+                    beta.kubernetes.io/os=linux
+                    kubernetes.io/arch=amd64
+                    kubernetes.io/hostname=worker-node
+                    kubernetes.io/os=linux
+                    node-role.kubernetes.io/control-plane=
+                    node.kubernetes.io/exclude-from-external-load-balancers=
+Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: unix:///var/run/crio/crio.sock
+                    node.alpha.kubernetes.io/ttl: 0
+                    volumes.kubernetes.io/controller-managed-attach-detach: true
+CreationTimestamp:  Sat, 13 Sep 2025 12:06:21 +0000
+Taints:             node-role.kubernetes.io/control-plane:NoSchedule
+Unschedulable:      false
+Lease:
+  HolderIdentity:  worker-node
+  AcquireTime:     <unset>
+  RenewTime:       Sat, 13 Sep 2025 12:28:40 +0000
+Conditions:
+  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
+  ----             ------  -----------------                 ------------------                ------                       -------
+  MemoryPressure   False   Sat, 13 Sep 2025 12:28:39 +0000   Sat, 13 Sep 2025 12:06:20 +0000   KubeletHasSufficientMemory   kubelet has sufficient memory available
+  DiskPressure     False   Sat, 13 Sep 2025 12:28:39 +0000   Sat, 13 Sep 2025 12:06:20 +0000   KubeletHasNoDiskPressure     kubelet has no disk pressure
+  PIDPressure      False   Sat, 13 Sep 2025 12:28:39 +0000   Sat, 13 Sep 2025 12:06:20 +0000   KubeletHasSufficientPID      kubelet has sufficient PID available
+  Ready            True    Sat, 13 Sep 2025 12:28:39 +0000   Sat, 13 Sep 2025 12:06:22 +0000   KubeletReady                 kubelet is posting ready status
+Addresses:
+  InternalIP:  192.168.1.46
+  Hostname:    worker-node
+Capacity:
+  cpu:                32
+  ephemeral-storage:  477532016Ki
+  hugepages-1Gi:      0
+  hugepages-2Mi:      0
+  memory:             65744092Ki
+  pods:               110
+Allocatable:
+  cpu:                32
+  ephemeral-storage:  440093505217
+  hugepages-1Gi:      0
+  hugepages-2Mi:      0
+  memory:             65641692Ki
+  pods:               110
+System Info:
+  Machine ID:                 be32ec3be51a4e3ba2b564f7030eb3bc
+  System UUID:                cb856c93-9b3d-82ab-481c-107c610dbc87
+  Boot ID:                    70d832a2-0060-4035-8ff9-d7d970650185
+  Kernel Version:             6.16.6-arch1-1
+  OS Image:                   Arch Linux
+  Operating System:           linux
+  Architecture:               amd64
+  Container Runtime Version:  cri-o://1.33.4
+  Kubelet Version:            v1.33.4
+  Kube-Proxy Version:         
+PodCIDR:                      10.244.0.0/24
+PodCIDRs:                     10.244.0.0/24
+Non-terminated Pods:          (9 in total)
+  Namespace                   Name                                       CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
+  ---------                   ----                                       ------------  ----------  ---------------  -------------  ---
+  kube-system                 calico-kube-controllers-d4544f494-f27zr    0 (0%)        0 (0%)      0 (0%)           0 (0%)         21m
+  kube-system                 calico-node-dqwwv                          250m (0%)     0 (0%)      0 (0%)           0 (0%)         4m49s
+  kube-system                 coredns-674b8bbfcf-d9j48                   100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     13m
+  kube-system                 coredns-674b8bbfcf-q8bhd                   100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     13m
+  kube-system                 etcd-worker-node                           100m (0%)     0 (0%)      100Mi (0%)       0 (0%)         22m
+  kube-system                 kube-apiserver-worker-node                 250m (0%)     0 (0%)      0 (0%)           0 (0%)         22m
+  kube-system                 kube-controller-manager-worker-node        200m (0%)     0 (0%)      0 (0%)           0 (0%)         22m
+  kube-system                 kube-proxy-24lnm                           0 (0%)        0 (0%)      0 (0%)           0 (0%)         22m
+  kube-system                 kube-scheduler-worker-node                 100m (0%)     0 (0%)      0 (0%)           0 (0%)         22m
+Allocated resources:
+  (Total limits may be over 100 percent, i.e., overcommitted.)
+  Resource           Requests    Limits
+  --------           --------    ------
+  cpu                1100m (3%)  0 (0%)
+  memory             240Mi (0%)  340Mi (0%)
+  ephemeral-storage  0 (0%)      0 (0%)
+  hugepages-1Gi      0 (0%)      0 (0%)
+  hugepages-2Mi      0 (0%)      0 (0%)
+Events:
+  Type    Reason                   Age   From             Message
+  ----    ------                   ----  ----             -------
+  Normal  Starting                 22m   kube-proxy       
+  Normal  Starting                 22m   kubelet          Starting kubelet.
+  Normal  NodeAllocatableEnforced  22m   kubelet          Updated Node Allocatable limit across pods
+  Normal  NodeHasSufficientMemory  22m   kubelet          Node worker-node status is now: NodeHasSufficientMemory
+  Normal  NodeHasNoDiskPressure    22m   kubelet          Node worker-node status is now: NodeHasNoDiskPressure
+  Normal  NodeHasSufficientPID     22m   kubelet          Node worker-node status is now: NodeHasSufficientPID
+  Normal  RegisteredNode           22m   node-controller  Node worker-node event: Registered Node worker-node in Controller
+
+===== Calico CRDs (ippools, felixconfigurations) =====
++ kubectl get ippools.crd.projectcalico.org -A -o wide || true
+No resources found
++ kubectl get felixconfigurations.crd.projectcalico.org -A -o yaml | sed -n '1,120p' || true
+apiVersion: v1
+items: []
+kind: List
+metadata:
+  resourceVersion: ""

--- a/k8s_calico_diag_20250913_122755.log
+++ b/k8s_calico_diag_20250913_122755.log
@@ -1,0 +1,579 @@
+
+===== Environment =====
++ kubectl version --client || true
+Client Version: v1.33.4
+Kustomize Version: v5.6.0
++ crio --version || true
+crio version 1.33.4
+   GitCommit:      unknown
+   GitCommitDate:  unknown
+   GitTreeState:   clean
+   BuildDate:      2025-09-02T11:28:42Z
+   GoVersion:      go1.24.6
+   Compiler:       gc
+   Platform:       linux/amd64
+   Linkmode:       dynamic
+   BuildTags:
+     containers_image_ostree_stub
+     apparmor
+     seccomp
+   LDFlags:           -X github.com/cri-o/cri-o/internal/version.buildDate=2025-09-02T11:28:42Z -compressdwarf=false -linkmode external
+   SeccompEnabled:   true
+   AppArmorEnabled:  false
+
+===== Nodes =====
++ kubectl get nodes -o wide
+NAME          STATUS   ROLES           AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE     KERNEL-VERSION   CONTAINER-RUNTIME
+worker-node   Ready    control-plane   21m   v1.33.4   192.168.1.46   <none>        Arch Linux   6.16.6-arch1-1   cri-o://1.33.4
+
+===== kube-system pods (Calico, CoreDNS, control plane) =====
++ kubectl -n kube-system get pods -o wide | grep -E 'calico|coredns|kube-|etcd' || true
+calico-kube-controllers-d4544f494-f27zr   0/1     CrashLoopBackOff   8 (3m11s ago)   20m     10.88.0.4      worker-node   <none>           <none>
+calico-node-dqwwv                         0/1     Init:1/3           4 (73s ago)     3m55s   192.168.1.46   worker-node   <none>           <none>
+coredns-674b8bbfcf-d9j48                  0/1     Running            6 (81s ago)     12m     127.0.0.1      worker-node   <none>           <none>
+coredns-674b8bbfcf-q8bhd                  0/1     Running            6 (91s ago)     12m     127.0.0.1      worker-node   <none>           <none>
+etcd-worker-node                          1/1     Running            0               21m     192.168.1.46   worker-node   <none>           <none>
+kube-apiserver-worker-node                1/1     Running            0               21m     192.168.1.46   worker-node   <none>           <none>
+kube-controller-manager-worker-node       1/1     Running            0               21m     192.168.1.46   worker-node   <none>           <none>
+kube-proxy-24lnm                          1/1     Running            0               21m     192.168.1.46   worker-node   <none>           <none>
+kube-scheduler-worker-node                1/1     Running            0               21m     192.168.1.46   worker-node   <none>           <none>
+
+===== Calico DaemonSet and Deployment =====
++ kubectl -n kube-system get ds calico-node -o wide || true
+NAME          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE   CONTAINERS    IMAGES                          SELECTOR
+calico-node   1         1         0       1            0           kubernetes.io/os=linux   20m   calico-node   docker.io/calico/node:v3.27.3   k8s-app=calico-node
++ kubectl -n kube-system get deploy calico-kube-controllers -o wide || true
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS                IMAGES                                      SELECTOR
+calico-kube-controllers   0/1     1            0           20m   calico-kube-controllers   docker.io/calico/kube-controllers:v3.27.3   k8s-app=calico-kube-controllers
+
+===== kube-system recent events =====
++ kubectl -n kube-system get events --sort-by=.lastTimestamp | tail -n 50
+12m         Normal    SuccessfulDelete               daemonset/calico-node                          Deleted pod: calico-node-9g8nm
+12m         Normal    SuccessfulCreate               replicaset/coredns-674b8bbfcf                  Created pod: coredns-674b8bbfcf-q8bhd
+12m         Normal    SuccessfulCreate               replicaset/coredns-674b8bbfcf                  Created pod: coredns-674b8bbfcf-d9j48
+12m         Normal    Started                        pod/calico-node-78p4k                          Started container upgrade-ipam
+12m         Normal    Created                        pod/calico-node-78p4k                          Created container: upgrade-ipam
+12m         Normal    Scheduled                      pod/calico-node-78p4k                          Successfully assigned kube-system/calico-node-78p4k to worker-node
+12m         Normal    Pulled                         pod/calico-node-78p4k                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+12m         Normal    Killing                        pod/coredns-674b8bbfcf-cwm9h                   Stopping container coredns
+12m         Normal    Scheduled                      pod/calico-node-9g8nm                          Successfully assigned kube-system/calico-node-9g8nm to worker-node
+12m         Warning   FailedMount                    pod/calico-node-9g8nm                          MountVolume.SetUp failed for volume "kube-api-access-ngkh6" : failed to fetch token: pod "calico-node-9g8nm" not found
+12m         Normal    Killing                        pod/coredns-674b8bbfcf-b5g4j                   Stopping container coredns
+12m         Warning   FailedToUpdateEndpoint         endpoints/kube-dns                             Failed to update endpoint kube-system/kube-dns: Endpoints "kube-dns" is invalid: subsets[0].notReadyAddresses[0].ip: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)
+12m         Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: endpoints[2].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)
+12m         Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: [endpoints[2].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), endpoints[3].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+12m         Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: [endpoints[1].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), endpoints[2].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+12m         Warning   FailedToUpdateEndpoint         endpoints/kube-dns                             Failed to update endpoint kube-system/kube-dns: Endpoints "kube-dns" is invalid: [subsets[0].notReadyAddresses[0].ip: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), subsets[0].notReadyAddresses[1].ip: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+10m         Warning   Unhealthy                      pod/coredns-674b8bbfcf-q8bhd                   Liveness probe failed: Get "http://127.0.0.1:8080/health": dial tcp 127.0.0.1:8080: connect: connection refused
+10m         Warning   Unhealthy                      pod/coredns-674b8bbfcf-d9j48                   Liveness probe failed: Get "http://127.0.0.1:8080/health": dial tcp 127.0.0.1:8080: connect: connection refused
+9m53s       Warning   Unhealthy                      pod/calico-kube-controllers-d4544f494-f27zr    Readiness probe failed: Error initializing datastore: Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+6m59s       Normal    Created                        pod/calico-node-78p4k                          Created container: install-cni
+6m59s       Normal    Started                        pod/calico-node-78p4k                          Started container install-cni
+6m59s       Normal    Pulled                         pod/calico-node-78p4k                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+4m57s       Warning   BackOff                        pod/calico-kube-controllers-d4544f494-f27zr    Back-off restarting failed container calico-kube-controllers in pod calico-kube-controllers-d4544f494-f27zr_kube-system(6be8928d-a3c1-40f7-81ac-1b03b4f92d80)
+4m31s       Normal    Started                        pod/calico-kube-controllers-d4544f494-f27zr    Started container calico-kube-controllers
+4m31s       Normal    Created                        pod/calico-kube-controllers-d4544f494-f27zr    Created container: calico-kube-controllers
+4m31s       Normal    Pulled                         pod/calico-kube-controllers-d4544f494-f27zr    Container image "docker.io/calico/kube-controllers:v3.27.3" already present on machine
+4m6s        Warning   BackOff                        pod/calico-node-78p4k                          Back-off restarting failed container install-cni in pod calico-node-78p4k_kube-system(820a1a6a-9267-400a-a1e9-ac24ae46847d)
+3m55s       Normal    Created                        pod/calico-node-dqwwv                          Created container: upgrade-ipam
+3m55s       Normal    SuccessfulCreate               daemonset/calico-node                          Created pod: calico-node-wjb6l
+3m55s       Normal    Started                        pod/calico-node-dqwwv                          Started container upgrade-ipam
+3m55s       Normal    Scheduled                      pod/calico-node-wjb6l                          Successfully assigned kube-system/calico-node-wjb6l to worker-node
+3m55s       Normal    Pulled                         pod/calico-node-dqwwv                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+3m55s       Normal    Scheduled                      pod/calico-node-dqwwv                          Successfully assigned kube-system/calico-node-dqwwv to worker-node
+3m55s       Normal    SuccessfulCreate               daemonset/calico-node                          Created pod: calico-node-dqwwv
+3m55s       Normal    SuccessfulDelete               daemonset/calico-node                          Deleted pod: calico-node-78p4k
+3m48s       Warning   FailedToUpdateEndpointSlices   service/kube-dns                               Error updating Endpoint Slices for Service kube-system/kube-dns: failed to update kube-dns-x2jxn EndpointSlice for Service kube-system/kube-dns: EndpointSlice.discovery.k8s.io "kube-dns-x2jxn" is invalid: [endpoints[0].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128), endpoints[1].addresses[0]: Invalid value: "127.0.0.1": may not be in the loopback range (127.0.0.0/8, ::1/128)]
+2m19s       Warning   Unhealthy                      pod/coredns-674b8bbfcf-d9j48                   Readiness probe failed: Get "http://127.0.0.1:8181/ready": dial tcp 127.0.0.1:8181: connect: connection refused
+2m19s       Warning   Unhealthy                      pod/coredns-674b8bbfcf-q8bhd                   Readiness probe failed: Get "http://127.0.0.1:8181/ready": dial tcp 127.0.0.1:8181: connect: connection refused
+96s         Normal    Killing                        pod/coredns-674b8bbfcf-q8bhd                   Container coredns failed liveness probe, will be restarted
+90s         Normal    Pulled                         pod/coredns-674b8bbfcf-q8bhd                   Container image "registry.k8s.io/coredns/coredns:v1.12.0" already present on machine
+90s         Normal    Created                        pod/coredns-674b8bbfcf-q8bhd                   Created container: coredns
+90s         Normal    Started                        pod/coredns-674b8bbfcf-q8bhd                   Started container coredns
+86s         Normal    Killing                        pod/coredns-674b8bbfcf-d9j48                   Container coredns failed liveness probe, will be restarted
+80s         Normal    Pulled                         pod/coredns-674b8bbfcf-d9j48                   Container image "registry.k8s.io/coredns/coredns:v1.12.0" already present on machine
+80s         Normal    Created                        pod/coredns-674b8bbfcf-d9j48                   Created container: coredns
+80s         Normal    Started                        pod/coredns-674b8bbfcf-d9j48                   Started container coredns
+33s         Warning   BackOff                        pod/calico-node-dqwwv                          Back-off restarting failed container install-cni in pod calico-node-dqwwv_kube-system(71d2ed41-09ea-460a-82ad-f3b2d78d0112)
+19s         Normal    Pulled                         pod/calico-node-dqwwv                          Container image "docker.io/calico/cni:v3.27.3" already present on machine
+19s         Normal    Created                        pod/calico-node-dqwwv                          Created container: install-cni
+19s         Normal    Started                        pod/calico-node-dqwwv                          Started container install-cni
+
+===== Describe calico-node pod: calico-node-dqwwv =====
++ kubectl -n kube-system describe pod calico-node-dqwwv | sed -n '1,200p'
+Name:                 calico-node-dqwwv
+Namespace:            kube-system
+Priority:             2000001000
+Priority Class Name:  system-node-critical
+Service Account:      calico-node
+Node:                 worker-node/192.168.1.46
+Start Time:           Sat, 13 Sep 2025 12:24:00 +0000
+Labels:               controller-revision-hash=6f86f5ff8b
+                      k8s-app=calico-node
+                      pod-template-generation=4
+Annotations:          kubectl.kubernetes.io/restartedAt: 2025-09-13T12:24:00Z
+Status:               Pending
+IP:                   192.168.1.46
+IPs:
+  IP:           192.168.1.46
+Controlled By:  DaemonSet/calico-node
+Init Containers:
+  upgrade-ipam:
+    Container ID:  cri-o://951d9b7ad777eee460def1d4e9a4b0741abc23849fd733a30e7126d8a2d2d4f8
+    Image:         docker.io/calico/cni:v3.27.3
+    Image ID:      docker.io/calico/cni@sha256:1f2c6a13d436b2ae056edd46552d23279d3aaf5d79152fb88cd959b634acfd6f
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      /opt/cni/bin/calico-ipam
+      -upgrade
+    State:          Terminated
+      Reason:       Completed
+      Exit Code:    0
+      Started:      Sat, 13 Sep 2025 12:24:00 +0000
+      Finished:     Sat, 13 Sep 2025 12:24:00 +0000
+    Ready:          True
+    Restart Count:  0
+    Environment Variables from:
+      kubernetes-services-endpoint  ConfigMap  Optional: true
+    Environment:
+      KUBERNETES_NODE_NAME:        (v1:spec.nodeName)
+      CALICO_NETWORKING_BACKEND:  <set to the key 'calico_backend' of config map 'calico-config'>  Optional: false
+      CALICO_IPV4POOL_CIDR:       10.244.0.0/16
+    Mounts:
+      /host/opt/cni/bin from cni-bin-dir (rw)
+      /var/lib/cni/networks from host-local-net-dir (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+  install-cni:
+    Container ID:  cri-o://af4cda100db45347053d598b98f88aeb881ff60b8b958977e0ea0eb031bdf29e
+    Image:         docker.io/calico/cni:v3.27.3
+    Image ID:      docker.io/calico/cni@sha256:1f2c6a13d436b2ae056edd46552d23279d3aaf5d79152fb88cd959b634acfd6f
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      /opt/cni/bin/install
+    State:          Running
+      Started:      Sat, 13 Sep 2025 12:27:36 +0000
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    1
+      Started:      Sat, 13 Sep 2025 12:26:12 +0000
+      Finished:     Sat, 13 Sep 2025 12:26:42 +0000
+    Ready:          False
+    Restart Count:  4
+    Environment Variables from:
+      kubernetes-services-endpoint  ConfigMap  Optional: true
+    Environment:
+      CNI_CONF_NAME:         10-calico.conflist
+      CNI_NETWORK_CONFIG:    <set to the key 'cni_network_config' of config map 'calico-config'>  Optional: false
+      KUBERNETES_NODE_NAME:   (v1:spec.nodeName)
+      CNI_MTU:               <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      SLEEP:                 false
+      CALICO_IPV4POOL_CIDR:  10.244.0.0/16
+    Mounts:
+      /host/etc/cni/net.d from cni-net-dir (rw)
+      /host/opt/cni/bin from cni-bin-dir (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+  mount-bpffs:
+    Container ID:  
+    Image:         docker.io/calico/node:v3.27.3
+    Image ID:      
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      calico-node
+      -init
+      -best-effort
+    State:          Waiting
+      Reason:       PodInitializing
+    Ready:          False
+    Restart Count:  0
+    Environment:
+      CALICO_IPV4POOL_CIDR:  10.244.0.0/16
+    Mounts:
+      /nodeproc from nodeproc (ro)
+      /sys/fs from sys-fs (rw)
+      /var/run/calico from var-run-calico (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+Containers:
+  calico-node:
+    Container ID:   
+    Image:          docker.io/calico/node:v3.27.3
+    Image ID:       
+    Port:           <none>
+    Host Port:      <none>
+    State:          Waiting
+      Reason:       PodInitializing
+    Ready:          False
+    Restart Count:  0
+    Requests:
+      cpu:      250m
+    Liveness:   exec [/bin/calico-node -felix-live -bird-live] delay=10s timeout=10s period=10s #success=1 #failure=6
+    Readiness:  exec [/bin/calico-node -felix-ready -bird-ready] delay=0s timeout=10s period=10s #success=1 #failure=3
+    Environment Variables from:
+      kubernetes-services-endpoint  ConfigMap  Optional: true
+    Environment:
+      DATASTORE_TYPE:                     kubernetes
+      WAIT_FOR_DATASTORE:                 true
+      NODENAME:                            (v1:spec.nodeName)
+      CALICO_NETWORKING_BACKEND:          <set to the key 'calico_backend' of config map 'calico-config'>  Optional: false
+      CLUSTER_TYPE:                       k8s,bgp
+      IP:                                 autodetect
+      CALICO_IPV4POOL_IPIP:               Always
+      CALICO_IPV4POOL_VXLAN:              Never
+      CALICO_IPV6POOL_VXLAN:              Never
+      FELIX_IPINIPMTU:                    <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      FELIX_VXLANMTU:                     <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      FELIX_WIREGUARDMTU:                 <set to the key 'veth_mtu' of config map 'calico-config'>  Optional: false
+      CALICO_DISABLE_FILE_LOGGING:        true
+      FELIX_DEFAULTENDPOINTTOHOSTACTION:  ACCEPT
+      FELIX_IPV6SUPPORT:                  false
+      FELIX_HEALTHENABLED:                true
+      CALICO_IPV4POOL_CIDR:               10.244.0.0/16
+    Mounts:
+      /host/etc/cni/net.d from cni-net-dir (rw)
+      /lib/modules from lib-modules (ro)
+      /run/xtables.lock from xtables-lock (rw)
+      /sys/fs/bpf from bpffs (rw)
+      /var/lib/calico from var-lib-calico (rw)
+      /var/log/calico/cni from cni-log-dir (ro)
+      /var/run/calico from var-run-calico (rw)
+      /var/run/nodeagent from policysync (rw)
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-gpgdm (ro)
+Conditions:
+  Type                        Status
+  PodReadyToStartContainers   True 
+  Initialized                 False 
+  Ready                       False 
+  ContainersReady             False 
+  PodScheduled                True 
+Volumes:
+  lib-modules:
+    Type:          HostPath (bare host directory volume)
+    Path:          /lib/modules
+    HostPathType:  
+  var-run-calico:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/run/calico
+    HostPathType:  
+  var-lib-calico:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/lib/calico
+    HostPathType:  
+  xtables-lock:
+    Type:          HostPath (bare host directory volume)
+    Path:          /run/xtables.lock
+    HostPathType:  FileOrCreate
+  sys-fs:
+    Type:          HostPath (bare host directory volume)
+    Path:          /sys/fs/
+    HostPathType:  DirectoryOrCreate
+  bpffs:
+    Type:          HostPath (bare host directory volume)
+    Path:          /sys/fs/bpf
+    HostPathType:  Directory
+  nodeproc:
+    Type:          HostPath (bare host directory volume)
+    Path:          /proc
+    HostPathType:  
+  cni-bin-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /opt/cni/bin
+    HostPathType:  
+  cni-net-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /etc/cni/net.d
+    HostPathType:  
+  cni-log-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/log/calico/cni
+    HostPathType:  
+  host-local-net-dir:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/lib/cni/networks
+    HostPathType:  
+  policysync:
+    Type:          HostPath (bare host directory volume)
+    Path:          /var/run/nodeagent
+    HostPathType:  DirectoryOrCreate
+  kube-api-access-gpgdm:
+    Type:                    Projected (a volume that contains injected data from multiple sources)
+    TokenExpirationSeconds:  3607
+    ConfigMapName:           kube-root-ca.crt
+    Optional:                false
+
+===== Logs: calico-node init container install-cni (tail) =====
++ kubectl -n kube-system logs calico-node-dqwwv -c install-cni --tail=200
+2025-09-13 12:27:36.089 [INFO][1] cni-installer/<nil> <nil>: Running as a Kubernetes pod
+2025-09-13 12:27:36.091 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/bandwidth"
+2025-09-13 12:27:36.091 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/bandwidth
+2025-09-13 12:27:36.125 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/calico"
+2025-09-13 12:27:36.125 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/calico
+2025-09-13 12:27:36.156 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/calico-ipam"
+2025-09-13 12:27:36.156 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/calico-ipam
+2025-09-13 12:27:36.158 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/flannel"
+2025-09-13 12:27:36.158 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/flannel
+2025-09-13 12:27:36.160 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/host-local"
+2025-09-13 12:27:36.160 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/host-local
+2025-09-13 12:27:36.162 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/loopback"
+2025-09-13 12:27:36.162 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/loopback
+2025-09-13 12:27:36.165 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/portmap"
+2025-09-13 12:27:36.165 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/portmap
+2025-09-13 12:27:36.167 [INFO][1] cni-installer/<nil> <nil>: File is already up to date, skipping file="/host/opt/cni/bin/tuning"
+2025-09-13 12:27:36.167 [INFO][1] cni-installer/<nil> <nil>: Installed /host/opt/cni/bin/tuning
+2025-09-13 12:27:36.167 [INFO][1] cni-installer/<nil> <nil>: Wrote Calico CNI binaries to /host/opt/cni/bin
+
+2025-09-13 12:27:36.201 [INFO][1] cni-installer/<nil> <nil>: CNI plugin version: v3.27.3
+2025-09-13 12:27:36.201 [INFO][1] cni-installer/<nil> <nil>: /host/secondary-bin-dir is not writeable, skipping
+2025-09-13 12:27:36.201 [WARNING][1] cni-installer/<nil> <nil>: Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
+
+===== Logs: calico-node main container (tail) =====
++ kubectl -n kube-system logs calico-node-dqwwv -c calico-node --tail=200
+Error from server (BadRequest): container "calico-node" in pod "calico-node-dqwwv" is waiting to start: PodInitializing
+
+===== Describe calico-kube-controllers pod: calico-kube-controllers-d4544f494-f27zr =====
++ kubectl -n kube-system describe pod calico-kube-controllers-d4544f494-f27zr | sed -n '1,200p'
+Name:                 calico-kube-controllers-d4544f494-f27zr
+Namespace:            kube-system
+Priority:             2000000000
+Priority Class Name:  system-cluster-critical
+Service Account:      calico-kube-controllers
+Node:                 worker-node/192.168.1.46
+Start Time:           Sat, 13 Sep 2025 12:07:43 +0000
+Labels:               k8s-app=calico-kube-controllers
+                      pod-template-hash=d4544f494
+Annotations:          <none>
+Status:               Running
+IP:                   10.88.0.4
+IPs:
+  IP:           10.88.0.4
+Controlled By:  ReplicaSet/calico-kube-controllers-d4544f494
+Containers:
+  calico-kube-controllers:
+    Container ID:   cri-o://aca84ceaa326548df1abc6debf2853ccf188cec0bc0a53797d19417ac5d0d0a7
+    Image:          docker.io/calico/kube-controllers:v3.27.3
+    Image ID:       docker.io/calico/kube-controllers@sha256:3e8bc2000187cc71346538aaa8e10cd7941ba75f744e315f48b3a3293399a495
+    Port:           <none>
+    Host Port:      <none>
+    State:          Waiting
+      Reason:       CrashLoopBackOff
+    Last State:     Terminated
+      Reason:       Error
+      Exit Code:    1
+      Started:      Sat, 13 Sep 2025 12:23:44 +0000
+      Finished:     Sat, 13 Sep 2025 12:24:44 +0000
+    Ready:          False
+    Restart Count:  8
+    Liveness:       exec [/usr/bin/check-status -l] delay=10s timeout=10s period=10s #success=1 #failure=6
+    Readiness:      exec [/usr/bin/check-status -r] delay=0s timeout=1s period=10s #success=1 #failure=3
+    Environment:
+      ENABLED_CONTROLLERS:  node
+      DATASTORE_TYPE:       kubernetes
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-szp9v (ro)
+Conditions:
+  Type                        Status
+  PodReadyToStartContainers   True 
+  Initialized                 True 
+  Ready                       False 
+  ContainersReady             False 
+  PodScheduled                True 
+Volumes:
+  kube-api-access-szp9v:
+    Type:                    Projected (a volume that contains injected data from multiple sources)
+    TokenExpirationSeconds:  3607
+    ConfigMapName:           kube-root-ca.crt
+    Optional:                false
+    DownwardAPI:             true
+QoS Class:                   BestEffort
+Node-Selectors:              kubernetes.io/os=linux
+Tolerations:                 CriticalAddonsOnly op=Exists
+                             node-role.kubernetes.io/control-plane:NoSchedule
+                             node-role.kubernetes.io/master:NoSchedule
+                             node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
+                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
+Events:
+  Type     Reason     Age                   From               Message
+  ----     ------     ----                  ----               -------
+  Normal   Pulling    20m                   kubelet            Pulling image "docker.io/calico/kube-controllers:v3.27.3"
+  Normal   Scheduled  20m                   default-scheduler  Successfully assigned kube-system/calico-kube-controllers-d4544f494-f27zr to worker-node
+  Normal   Pulled     20m                   kubelet            Successfully pulled image "docker.io/calico/kube-controllers:v3.27.3" in 4.652s (11.963s including waiting). Image size: 75746522 bytes.
+  Warning  Unhealthy  18m                   kubelet            Readiness probe errored and resulted in unknown state: rpc error: code = Unknown desc = command error: cannot register an exec PID: container is stopping, stdout: , stderr: , exit code -1
+  Warning  Unhealthy  18m (x11 over 20m)    kubelet            Readiness probe failed: initialized to false
+  Warning  Unhealthy  18m (x5 over 19m)     kubelet            Liveness probe failed: initialized to false
+  Warning  Unhealthy  18m (x4 over 19m)     kubelet            Liveness probe failed: Error initializing datastore: Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+  Normal   Killing    13m (x3 over 18m)     kubelet            Container calico-kube-controllers failed liveness probe, will be restarted
+  Warning  Unhealthy  9m54s (x11 over 19m)  kubelet            Readiness probe failed: Error initializing datastore: Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+  Warning  BackOff    4m58s (x51 over 17m)  kubelet            Back-off restarting failed container calico-kube-controllers in pod calico-kube-controllers-d4544f494-f27zr_kube-system(6be8928d-a3c1-40f7-81ac-1b03b4f92d80)
+  Normal   Created    4m32s (x8 over 20m)   kubelet            Created container: calico-kube-controllers
+  Normal   Pulled     4m32s (x7 over 19m)   kubelet            Container image "docker.io/calico/kube-controllers:v3.27.3" already present on machine
+  Normal   Started    4m32s (x8 over 20m)   kubelet            Started container calico-kube-controllers
+
+===== Logs: calico-kube-controllers (tail) =====
++ kubectl -n kube-system logs calico-kube-controllers-d4544f494-f27zr --tail=200
+2025-09-13 12:23:44.037 [INFO][1] main.go 107: Loaded configuration from environment config=&config.Config{LogLevel:"info", WorkloadEndpointWorkers:1, ProfileWorkers:1, PolicyWorkers:1, NodeWorkers:1, Kubeconfig:"", DatastoreType:"kubernetes"}
+2025-09-13 12:23:44.038 [WARNING][1] winutils.go 144: Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
+2025-09-13 12:23:44.038 [INFO][1] main.go 131: Ensuring Calico datastore is initialized
+2025-09-13 12:24:14.038 [ERROR][1] client.go 295: Error getting cluster information config ClusterInformation="default" error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:14.038 [INFO][1] main.go 138: Failed to initialize datastore error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:44.063 [ERROR][1] client.go 295: Error getting cluster information config ClusterInformation="default" error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:44.063 [INFO][1] main.go 138: Failed to initialize datastore error=Get "https://10.96.0.1:443/apis/crd.projectcalico.org/v1/clusterinformations/default": dial tcp 10.96.0.1:443: i/o timeout
+2025-09-13 12:24:44.063 [FATAL][1] main.go 151: Failed to initialize Calico datastore
+
+===== Host CNI directories and configs =====
++ ls -ld /etc/cni/net.d /opt/cni/bin
+drwxr-xr-x 2 root root 4096 sep 13 12:15 /etc/cni/net.d
+drwxr-xr-x 2 root root 4096 sep 13 12:27 /opt/cni/bin
++ ls -l /etc/cni/net.d || true
+total 8
+-rw-r--r-- 1 root root 553 ago 29 17:29 10-crio-bridge.conflist.bak
+-rw-r--r-- 1 root root  61 ago 29 17:00 99-loopback.conf
++ ls -l /opt/cni/bin | egrep 'calico|loopback|host-local|portmap' || true
+egrep: warning: egrep is obsolescent; using grep -E
+-rwxr-xr-x 1 root root 62171883 sep 13 12:07 calico
+-rwxr-xr-x 1 root root 62171883 sep 13 12:07 calico-ipam
+-rwxr-xr-x 1 root root  3522445 sep 13 12:07 host-local
+-rwxr-xr-x 1 root root  3603570 sep 13 12:07 loopback
+-rwxr-xr-x 1 root root  4040630 sep 13 12:07 portmap
+
+===== CNI config: /etc/cni/net.d/10-crio-bridge.conflist.bak =====
++ cat /etc/cni/net.d/10-crio-bridge.conflist.bak
+{
+  "cniVersion": "1.0.0",
+  "name": "crio-bridge",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": false,
+      "hairpinMode": true,
+      "capabilities": { "ips": true },
+      "ipam": {
+        "type": "host-local",
+        "routes": [ { "dst": "0.0.0.0/0" } ],
+        "ranges": [ [ { "subnet": "10.88.0.0/16" } ] ]
+      }
+    },
+    { "type": "firewall" },
+    { "type": "tuning" },
+    { "type": "portmap", "capabilities": { "portMappings": true } }
+  ]
+}
+
+
+===== CNI config: /etc/cni/net.d/99-loopback.conf =====
++ cat /etc/cni/net.d/99-loopback.conf
+{ "cniVersion": "1.0.0", "name": "lo", "type": "loopback" }
+
+
+===== Kernel/sysctl required by CNI =====
++ sysctl net.ipv4.ip_forward || true
+net.ipv4.ip_forward = 1
++ lsmod | grep br_netfilter || true
+br_netfilter           36864  0
+bridge                454656  1 br_netfilter
++ sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables || true
+net.bridge.bridge-nf-call-iptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+
+===== Node detail (taints/conditions/addresses) =====
++ kubectl describe node worker-node | sed -n '1,200p'
+Name:               worker-node
+Roles:              control-plane
+Labels:             beta.kubernetes.io/arch=amd64
+                    beta.kubernetes.io/os=linux
+                    kubernetes.io/arch=amd64
+                    kubernetes.io/hostname=worker-node
+                    kubernetes.io/os=linux
+                    node-role.kubernetes.io/control-plane=
+                    node.kubernetes.io/exclude-from-external-load-balancers=
+Annotations:        kubeadm.alpha.kubernetes.io/cri-socket: unix:///var/run/crio/crio.sock
+                    node.alpha.kubernetes.io/ttl: 0
+                    volumes.kubernetes.io/controller-managed-attach-detach: true
+CreationTimestamp:  Sat, 13 Sep 2025 12:06:21 +0000
+Taints:             node-role.kubernetes.io/control-plane:NoSchedule
+Unschedulable:      false
+Lease:
+  HolderIdentity:  worker-node
+  AcquireTime:     <unset>
+  RenewTime:       Sat, 13 Sep 2025 12:27:50 +0000
+Conditions:
+  Type             Status  LastHeartbeatTime                 LastTransitionTime                Reason                       Message
+  ----             ------  -----------------                 ------------------                ------                       -------
+  MemoryPressure   False   Sat, 13 Sep 2025 12:27:07 +0000   Sat, 13 Sep 2025 12:06:20 +0000   KubeletHasSufficientMemory   kubelet has sufficient memory available
+  DiskPressure     False   Sat, 13 Sep 2025 12:27:07 +0000   Sat, 13 Sep 2025 12:06:20 +0000   KubeletHasNoDiskPressure     kubelet has no disk pressure
+  PIDPressure      False   Sat, 13 Sep 2025 12:27:07 +0000   Sat, 13 Sep 2025 12:06:20 +0000   KubeletHasSufficientPID      kubelet has sufficient PID available
+  Ready            True    Sat, 13 Sep 2025 12:27:07 +0000   Sat, 13 Sep 2025 12:06:22 +0000   KubeletReady                 kubelet is posting ready status
+Addresses:
+  InternalIP:  192.168.1.46
+  Hostname:    worker-node
+Capacity:
+  cpu:                32
+  ephemeral-storage:  477532016Ki
+  hugepages-1Gi:      0
+  hugepages-2Mi:      0
+  memory:             65744092Ki
+  pods:               110
+Allocatable:
+  cpu:                32
+  ephemeral-storage:  440093505217
+  hugepages-1Gi:      0
+  hugepages-2Mi:      0
+  memory:             65641692Ki
+  pods:               110
+System Info:
+  Machine ID:                 be32ec3be51a4e3ba2b564f7030eb3bc
+  System UUID:                cb856c93-9b3d-82ab-481c-107c610dbc87
+  Boot ID:                    70d832a2-0060-4035-8ff9-d7d970650185
+  Kernel Version:             6.16.6-arch1-1
+  OS Image:                   Arch Linux
+  Operating System:           linux
+  Architecture:               amd64
+  Container Runtime Version:  cri-o://1.33.4
+  Kubelet Version:            v1.33.4
+  Kube-Proxy Version:         
+PodCIDR:                      10.244.0.0/24
+PodCIDRs:                     10.244.0.0/24
+Non-terminated Pods:          (9 in total)
+  Namespace                   Name                                       CPU Requests  CPU Limits  Memory Requests  Memory Limits  Age
+  ---------                   ----                                       ------------  ----------  ---------------  -------------  ---
+  kube-system                 calico-kube-controllers-d4544f494-f27zr    0 (0%)        0 (0%)      0 (0%)           0 (0%)         20m
+  kube-system                 calico-node-dqwwv                          250m (0%)     0 (0%)      0 (0%)           0 (0%)         3m56s
+  kube-system                 coredns-674b8bbfcf-d9j48                   100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     12m
+  kube-system                 coredns-674b8bbfcf-q8bhd                   100m (0%)     0 (0%)      70Mi (0%)        170Mi (0%)     12m
+  kube-system                 etcd-worker-node                           100m (0%)     0 (0%)      100Mi (0%)       0 (0%)         21m
+  kube-system                 kube-apiserver-worker-node                 250m (0%)     0 (0%)      0 (0%)           0 (0%)         21m
+  kube-system                 kube-controller-manager-worker-node        200m (0%)     0 (0%)      0 (0%)           0 (0%)         21m
+  kube-system                 kube-proxy-24lnm                           0 (0%)        0 (0%)      0 (0%)           0 (0%)         21m
+  kube-system                 kube-scheduler-worker-node                 100m (0%)     0 (0%)      0 (0%)           0 (0%)         21m
+Allocated resources:
+  (Total limits may be over 100 percent, i.e., overcommitted.)
+  Resource           Requests    Limits
+  --------           --------    ------
+  cpu                1100m (3%)  0 (0%)
+  memory             240Mi (0%)  340Mi (0%)
+  ephemeral-storage  0 (0%)      0 (0%)
+  hugepages-1Gi      0 (0%)      0 (0%)
+  hugepages-2Mi      0 (0%)      0 (0%)
+Events:
+  Type    Reason                   Age   From             Message
+  ----    ------                   ----  ----             -------
+  Normal  Starting                 21m   kube-proxy       
+  Normal  Starting                 21m   kubelet          Starting kubelet.
+  Normal  NodeAllocatableEnforced  21m   kubelet          Updated Node Allocatable limit across pods
+  Normal  NodeHasSufficientMemory  21m   kubelet          Node worker-node status is now: NodeHasSufficientMemory
+  Normal  NodeHasNoDiskPressure    21m   kubelet          Node worker-node status is now: NodeHasNoDiskPressure
+  Normal  NodeHasSufficientPID     21m   kubelet          Node worker-node status is now: NodeHasSufficientPID
+  Normal  RegisteredNode           21m   node-controller  Node worker-node event: Registered Node worker-node in Controller
+
+===== Calico CRDs (ippools, felixconfigurations) =====
++ kubectl get ippools.crd.projectcalico.org -A -o wide || true
+No resources found
++ kubectl get felixconfigurations.crd.projectcalico.org -A -o yaml | sed -n '1,120p' || true
+apiVersion: v1
+items: []
+kind: List
+metadata:
+  resourceVersion: ""

--- a/scripts/k8s_calico_diag.sh
+++ b/scripts/k8s_calico_diag.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kubernetes + Calico diagnostics helper
+# Usage: ./scripts/k8s_calico_diag.sh [output_log]
+# If output_log is omitted, a timestamped log will be created in the current directory.
+
+OUT="${1:-k8s_calico_diag_$(date +%Y%m%d_%H%M%S).log}"
+
+log() {
+  echo -e "\n===== $* =====" | tee -a "$OUT"
+}
+
+run() {
+  # Print the command and append both stdout and stderr to the log
+  echo "+ $*" | tee -a "$OUT"
+  eval "$*" 2>&1 | tee -a "$OUT" || true
+}
+
+run_sudo() {
+  if sudo -n true 2>/dev/null; then
+    run "sudo $*"
+  else
+    run "$*"
+  fi
+}
+
+log "Environment"
+run "kubectl version --client || true"
+run "crio --version || true"
+
+log "Nodes"
+run "kubectl get nodes -o wide"
+
+log "kube-system pods (Calico, CoreDNS, control plane)"
+run "kubectl -n kube-system get pods -o wide | grep -E 'calico|coredns|kube-|etcd' || true"
+
+log "Calico DaemonSet and Deployment"
+run "kubectl -n kube-system get ds calico-node -o wide || true"
+run "kubectl -n kube-system get deploy calico-kube-controllers -o wide || true"
+
+log "kube-system recent events"
+run "kubectl -n kube-system get events --sort-by=.lastTimestamp | tail -n 50"
+
+# Resolve pod names
+CALICO_NODE_POD="$(kubectl -n kube-system get pods -l k8s-app=calico-node -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+CALICO_CTRL_POD="$(kubectl -n kube-system get pods -l k8s-app=calico-kube-controllers -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+
+if [[ -n "${CALICO_NODE_POD}" ]]; then
+  log "Describe calico-node pod: ${CALICO_NODE_POD}"
+  run "kubectl -n kube-system describe pod ${CALICO_NODE_POD} | sed -n '1,200p'"
+  log "Logs: calico-node init container install-cni (tail)"
+  run "kubectl -n kube-system logs ${CALICO_NODE_POD} -c install-cni --tail=200"
+  log "Logs: calico-node main container (tail)"
+  run "kubectl -n kube-system logs ${CALICO_NODE_POD} -c calico-node --tail=200"
+else
+  log "No calico-node pod found"
+fi
+
+if [[ -n "${CALICO_CTRL_POD}" ]]; then
+  log "Describe calico-kube-controllers pod: ${CALICO_CTRL_POD}"
+  run "kubectl -n kube-system describe pod ${CALICO_CTRL_POD} | sed -n '1,200p'"
+  log "Logs: calico-kube-controllers (tail)"
+  run "kubectl -n kube-system logs ${CALICO_CTRL_POD} --tail=200"
+else
+  log "No calico-kube-controllers pod found"
+fi
+
+log "Host CNI directories and configs"
+run_sudo "ls -ld /etc/cni/net.d /opt/cni/bin"
+run_sudo "ls -l /etc/cni/net.d || true"
+run_sudo "ls -l /opt/cni/bin | egrep 'calico|loopback|host-local|portmap' || true"
+for f in /etc/cni/net.d/*; do
+  if [[ -f "$f" ]]; then
+    log "CNI config: $f"
+    run_sudo "cat $f"
+  fi
+done
+
+log "Kernel/sysctl required by CNI"
+run "sysctl net.ipv4.ip_forward || true"
+run "lsmod | grep br_netfilter || true"
+run "sysctl net.bridge.bridge-nf-call-iptables net.bridge.bridge-nf-call-ip6tables || true"
+
+log "Node detail (taints/conditions/addresses)"
+NODE_NAME="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
+run "kubectl describe node ${NODE_NAME} | sed -n '1,200p'"
+
+log "Calico CRDs (ippools, felixconfigurations)"
+run "kubectl get ippools.crd.projectcalico.org -A -o wide || true"
+run "kubectl get felixconfigurations.crd.projectcalico.org -A -o yaml | sed -n '1,120p' || true"
+
+echo "\nDiagnostics written to: $OUT"
+
+


### PR DESCRIPTION
## Summary

Documents local Ingress access via port-forward with sudo KUBECONFIG and non-root alternative (8080).
Adds /etc/hosts guidance and curl verification.
Qualifies demo image to docker.io/hashicorp/http-echo:0.2.3 (fixes CRI-O short-name ImageInspectError).
Tested: demo accessible via Ingress with Host headers

## Type

- [x] chore(hardening)
- [ ] fix
- [ ] feat
- [x] docs

## Tests

- [ ] Unit tests added/updated
- [x] CI green

