### PR TITLE
docs(readme): link to underpassai.com homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Specialized agents react to real events, not prompts.
 [![Runtime CI](https://github.com/underpass-ai/underpass-runtime/actions/workflows/ci.yml/badge.svg)](https://github.com/underpass-ai/underpass-runtime)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
+[underpassai.com](https://underpassai.com)
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Adds a one-line pointer in the README header to https://underpassai.com so the project's homepage is discoverable from this repo.

## Why
- The repo currently has no link back to the Underpass AI website. Adding one improves discoverability for visitors arriving from search engines or other Underpass repos, and contributes a backlink that helps the website rank for relevant queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)